### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: 发布
+permissions:
+  contents: read
 on:
   push:
     tags: [v*.*.*]


### PR DESCRIPTION
Potential fix for [https://github.com/ZhangXiChang/starlink/security/code-scanning/2](https://github.com/ZhangXiChang/starlink/security/code-scanning/2)

To correctly address this issue, add a `permissions` block to the workflow file at the root level, specifying the least privilege access needed. Since the `verify` and `web` jobs do not appear to perform write operations on repository contents or pull requests, a minimal permission (e.g., `contents: read`) should be set at the workflow root, thereby limiting default permissions for all jobs except those (like `windows`) that explicitly declare broader permission scope. The best fix is to insert the following block at the top of the YAML file, after the workflow name and before `on:`:

```yaml
permissions:
  contents: read
```

This ensures all jobs default to read-only access unless overridden. No additional imports or definitions are necessary. Only `.github/workflows/deploy.yml` is to be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
