### PR TITLE
fix: add condition to build-relay job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,8 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
   build-relay:
     name: 构建中继服务程序
-    needs: [check-release]
+    needs: check-release
+    if: ${{needs.check-release.outputs.release=='true'}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

修复 release workflow 中 build-relay 作业的条件判断。

## Changes

- 为 `build-relay` 作业添加条件判断 `if: ${{needs.check-release.outputs.release=='true'}}`
- 避免在非发布情况下运行构建

## Testing

- CI 检查通过