### PR TITLE
chore: add basedpyright, refactor android sign config with better type safety

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"check": "run-p 'check:*'",
 		"check:tsc": "tsc",
 		"check:eslint": "eslint src",
-		"check:format": "biome check",
+		"check:script": "uv run basedpyright scripts",
 		"native:dev": "tauri dev",
 		"native:build": "tauri build",
 		"native:build:debug": "tauri build --debug",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,12 +2,19 @@
 name = "scripts"
 version = "0.1.0"
 requires-python = ">=3.14"
-dependencies = [
+
+dependencies = ["kopyt>=0.0.2"]
+
+[dependency-groups]
+lint = ["basedpyright>=1.39.3"]
+jupyter = [
     "black>=26.3.1",
     "isort>=8.0.1",
     "jupyterlab>=4.5.7",
     "jupyterlab-code-formatter>=3.0.3",
-    "jupyterlab-lsp>=5.2.0",
-    "kopyt>=0.0.2",
-    "python-lsp-server[all]>=1.14.0",
+    "jupyterlab-lsp>=5.3.0",
+    "python-lsp-server>=1.14.0",
 ]
+
+[tool.pyright]
+typeCheckingMode = "standard"

--- a/scripts/insert_android_sign_config.py
+++ b/scripts/insert_android_sign_config.py
@@ -1,7 +1,7 @@
 from argparse import ArgumentParser
 from os import path
 from shutil import copyfile
-from typing import Optional
+from typing import Optional, TypeGuard
 from kopyt import Parser
 from kopyt.node import (
     CallSuffix,
@@ -14,11 +14,13 @@ from kopyt.node import (
 from kopyt.position import Position
 
 
-def is_postfix_unary_expression(node) -> bool:
+def is_postfix_unary_expression(node) -> TypeGuard[PostfixUnaryExpression]:
     return isinstance(node, PostfixUnaryExpression)
 
 
-def is_simple_identifier(node, value: Optional[str] = None) -> bool:
+def is_simple_identifier(
+    node, value: Optional[str] = None
+) -> TypeGuard[SimpleIdentifier]:
     if not isinstance(node, SimpleIdentifier):
         return False
     if value is not None and node.value != value:
@@ -26,7 +28,7 @@ def is_simple_identifier(node, value: Optional[str] = None) -> bool:
     return True
 
 
-def is_call_suffix(node) -> bool:
+def is_call_suffix(node) -> TypeGuard[CallSuffix]:
     return isinstance(node, CallSuffix)
 
 
@@ -34,6 +36,18 @@ def get_call_suffix_with_lambda(node) -> Optional[CallSuffix]:
     if is_call_suffix(node) and node.lambda_expression is not None:
         return node
     return None
+
+
+def _has_release_value_arg(arguments) -> bool:
+    """Check if any ValueArgument wraps a LineStringLiteral '"release"'."""
+    for arg in arguments:
+        if not isinstance(arg, ValueArgument):
+            continue
+        if not isinstance(arg.value, LineStringLiteral):
+            continue
+        if arg.value.value == '"release"':
+            return True
+    return False
 
 
 def find_suffixes_with_lambda(postfix_node: PostfixUnaryExpression) -> list[CallSuffix]:
@@ -68,14 +82,8 @@ def find_call_suffix_with_release_arg(
             continue
         if suffix.arguments is None:
             continue
-
-        for arg in suffix.arguments:
-            if not isinstance(arg, ValueArgument):
-                continue
-            if not isinstance(arg.value, LineStringLiteral):
-                continue
-            if arg.value.value == '"release"':
-                return suffix
+        if _has_release_value_arg(suffix.arguments):
+            return suffix
 
     return None
 
@@ -87,6 +95,7 @@ def find_release_buildtype_suffix(
         call_suffix = get_call_suffix_with_lambda(buildtypes_suffix)
         if not call_suffix:
             continue
+        assert call_suffix.lambda_expression is not None
 
         buildtypes_lambda = call_suffix.lambda_expression.value
         buildtypes_expr = find_expression_by_name(
@@ -138,10 +147,10 @@ signing_configs_code = """signingConfigs {
 use_signing_configs_code = 'signingConfig = signingConfigs.getByName("release")'
 
 for root_statement in gradle_build_script.statements:
-    if not is_postfix_unary_expression(root_statement.statement):
+    android_expr = root_statement.statement
+    if not is_postfix_unary_expression(android_expr):
         continue
 
-    android_expr = root_statement.statement
     if not is_simple_identifier(android_expr.expression, "android"):
         continue
 
@@ -150,11 +159,13 @@ for root_statement in gradle_build_script.statements:
         continue
 
     android_call = call_suffixes[0]
-    android_lambda = android_call.lambda_expression.value
+    android_lambda = android_call.lambda_expression
+    if android_lambda is None:
+        continue
 
-    android_lambda.statements = [Parser(signing_configs_code).parse_statement()] + list(
-        android_lambda.statements
-    )
+    android_lambda.value.statements = [
+        Parser(signing_configs_code).parse_statement()
+    ] + list(android_lambda.value.statements)
 
     release_suffix = find_release_buildtype_suffix(android_expr)
     if release_suffix and release_suffix.lambda_expression:

--- a/uv.lock
+++ b/uv.lock
@@ -137,6 +137,18 @@ wheels = [
 ]
 
 [[package]]
+name = "basedpyright"
+version = "1.39.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodejs-wheel-binaries" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/19/5a5b9b9197973da732638957be3a65cf514d2f5a4964eeedbf33b6c65bbd/basedpyright-1.39.3.tar.gz", hash = "sha256:2f794e6b5f4260fb89f614ca6cd23c6f305373bb6b50c4ed7794ff2ae647fb14", size = 25503187, upload-time = "2026-04-20T22:14:47.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/5c/f950c1239ad26f3bb453e665428a2cf1893995de725a5eb0b64a2520b366/basedpyright-1.39.3-py3-none-any.whl", hash = "sha256:aba760dc83307727554f936d6b4381caa14482f30dbc2173167710e217c1f7ab", size = 12419181, upload-time = "2026-04-20T22:14:51.975Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -738,15 +750,15 @@ wheels = [
 
 [[package]]
 name = "jupyterlab-lsp"
-version = "5.2.0"
+version = "5.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jupyter-lsp" },
     { name = "jupyterlab" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/b6/eb54a1578618eccc081d89cdf4800f438eb5b256513b36232b7dfa05b07b/jupyterlab_lsp-5.2.0.tar.gz", hash = "sha256:63684885b35c1dc9d83e54b4b06380c9375ad7d751a2975649b357308c8d30b9", size = 772532, upload-time = "2025-07-18T21:35:18.569Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/72/38878b13f73fdbff3b776d274ef1b070e1a8afc824049b67ef5666b6b5f0/jupyterlab_lsp-5.3.0.tar.gz", hash = "sha256:bdf014febc0ec297ff69087e957549d724eb0c29df3f24d4f4c40758a71afc3f", size = 761351, upload-time = "2026-04-02T08:10:05.004Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/0a/faf41c7a22b363a2746a41d66081000c84dc055e98e22cc3dfdf121be6c9/jupyterlab_lsp-5.2.0-py3-none-any.whl", hash = "sha256:fe4ec7e3479fc8c4fc01ac3c7cf08c8b5d2332ffbe487b9eab0cf9e6eead267d", size = 1595423, upload-time = "2025-07-18T21:35:14.879Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7a/cc44f9b548f126372ed48ca0f9691f7802204e1dbdea14ab091f411900fb/jupyterlab_lsp-5.3.0-py3-none-any.whl", hash = "sha256:89f519c8de8ca0835551f40ddf69bf6a769411b0b1e75f5752fbe38d45e75f23", size = 1571008, upload-time = "2026-04-02T08:10:00.033Z" },
 ]
 
 [[package]]
@@ -925,6 +937,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "nodejs-wheel-binaries"
+version = "24.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/70/a1e4f4d5986768ab90cc860b1cc3660fd2ded74ca175a900a5c29f839c7d/nodejs_wheel_binaries-24.15.0.tar.gz", hash = "sha256:b43f5c4f6e5768d8845b2ae4682eb703a19bf7aadc84187e2d903ed3a611c859", size = 8057, upload-time = "2026-04-19T15:48:16.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/66/54051d14853d6ab4fb85f8be9b042b530be653357fb9a19557498bc91ab7/nodejs_wheel_binaries-24.15.0-py2.py3-none-macosx_13_0_arm64.whl", hash = "sha256:a6232fa8b754220941f52388c8ead923f7c1c7fdf0ea0d98f657523bd9a81ef4", size = 55173485, upload-time = "2026-04-19T15:47:34.561Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5f/66acada164da5ca10a0824db021aa7394ae18396c550cd9280e839a43126/nodejs_wheel_binaries-24.15.0-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:001a6b62c69d9109c1738163cca00608dd2722e8663af59300054ea02610972d", size = 55348100, upload-time = "2026-04-19T15:47:40.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2d/0cbd5ff40c9bb030ca1735d8f8793bd74f08a4cbd49100a1d19313ea57ab/nodejs_wheel_binaries-24.15.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:0fbc48765e60ed0ff30d43898dbf5cadbadf2e5f1e7f204afc2b01493b7ebce6", size = 59668206, upload-time = "2026-04-19T15:47:46.848Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d5/91ac63951ec75927a486b83b8cafe650e360fa70ac01dc94adfb32b93b97/nodejs_wheel_binaries-24.15.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:20ee0536809795da8a4942fc1ab4cbdebbcaaf29383eab67ba8874268fb00008", size = 60206736, upload-time = "2026-04-19T15:47:52.668Z" },
+    { url = "https://files.pythonhosted.org/packages/db/72/dc22776974d928869c0c30d23ee98ed7df254243c2df68f09f5963e8e8b8/nodejs_wheel_binaries-24.15.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1fade6c214285e72472ca40a631e98ff36559671cd5eefc8bf009471d67f04b4", size = 61720456, upload-time = "2026-04-19T15:47:58.325Z" },
+    { url = "https://files.pythonhosted.org/packages/01/0a/34461b9050cb45ee371dccdefc622aef6351506ea2691b08fc761ca67150/nodejs_wheel_binaries-24.15.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3984cb8d87766567aee67a49743227ab40ede6f47734ec990ff90e50b74e7740", size = 62326172, upload-time = "2026-04-19T15:48:04.094Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/17/09252bf35672dba926649d59dfe51443a0f6955ad13784e91131d5ec82a2/nodejs_wheel_binaries-24.15.0-py2.py3-none-win_amd64.whl", hash = "sha256:a437601956b532dcb3082046e6978e622733f90edc0932cbb9adb3bb97a16501", size = 41543461, upload-time = "2026-04-19T15:48:09.332Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7e/b649777d148e1e0c2ce349156603cdb12f7ed99921b95d93717393650193/nodejs_wheel_binaries-24.15.0-py2.py3-none-win_arm64.whl", hash = "sha256:bdf4a431e08321a32efc604111c6f23941f87055d796a537e8c4110daecad23f", size = 39233248, upload-time = "2026-04-19T15:48:13.326Z" },
 ]
 
 [[package]]
@@ -1416,6 +1444,7 @@ name = "scripts"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "basedpyright" },
     { name = "black" },
     { name = "isort" },
     { name = "jupyterlab" },
@@ -1427,11 +1456,12 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "basedpyright", specifier = ">=1.39.3" },
     { name = "black", specifier = ">=26.3.1" },
     { name = "isort", specifier = ">=8.0.1" },
     { name = "jupyterlab", specifier = ">=4.5.7" },
     { name = "jupyterlab-code-formatter", specifier = ">=3.0.3" },
-    { name = "jupyterlab-lsp", specifier = ">=5.2.0" },
+    { name = "jupyterlab-lsp", specifier = ">=5.3.0" },
     { name = "kopyt", specifier = ">=0.0.2" },
     { name = "python-lsp-server", extras = ["all"], specifier = ">=1.14.0" },
 ]


### PR DESCRIPTION
- Add basedpyright as Python type checker, replacing biome for script checks
- Refactor insert_android_sign_config.py with TypeGuard type predicates, null safety checks, and extracted helpers
- Restructure pyproject.toml dependency groups (lint / jupyter)
- Bump jupyterlab-lsp to 5.3.0