### PR TITLE
[codex] update chat data contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"test": "playwright test",
 		"format": "biome check --write",
 		"check": "run-p 'check:*'",
+		"check:schema-contract": "bun test ./scripts/schema_contract.test.ts",
 		"check:tsc": "tsc",
 		"check:eslint": "eslint src",
 		"check:script": "uv run basedpyright scripts",

--- a/schema.prisma
+++ b/schema.prisma
@@ -18,16 +18,41 @@ model user {
 }
 
 model friend {
-  id       String @id
   owner_id String
+  id       String
   name     String
   avatar   Bytes?
   bio      String
+
+  @@id([owner_id, id])
 }
 
 model chat_message {
-  timestamp    DateTime @id @default(now())
-  owner_id     String
-  chat_user_id String
-  content      String
+  id            String   @id
+  owner_id      String
+  chat_user_id  String
+  sender_id     String
+  content       String
+  status        String   @default("sent")
+  created_at    DateTime @default(now())
+  sort_at       BigInt
+  retry_count   Int      @default(0)
+  error_message String?
+
+  @@index([owner_id, chat_user_id, sort_at])
+  @@index([owner_id, status])
+}
+
+model friend_request {
+  id            String   @id
+  owner_id      String
+  remote_id     String
+  direction     String
+  status        String   @default("pending")
+  created_at    DateTime @default(now())
+  sort_at       BigInt
+  error_message String?
+
+  @@unique([owner_id, remote_id, direction])
+  @@index([owner_id, status, sort_at])
 }

--- a/scripts/schema_contract.test.ts
+++ b/scripts/schema_contract.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const schema = readFileSync("schema.prisma", "utf-8");
+const endpointTypes = readFileSync("src/lib/endpoint/types.ts", "utf-8");
+
+const modelBody = (name: string) => {
+	const match = schema.match(new RegExp(`model ${name} \\{([\\s\\S]*?)\\n\\}`));
+	if (!match) {
+		throw new Error(`model ${name} was not found`);
+	}
+	return match[1];
+};
+
+describe("database schema contract", () => {
+	test("friend rows are scoped by local owner and remote id", () => {
+		const friend = modelBody("friend");
+
+		expect(friend).not.toContain("id       String @id");
+		expect(friend).toContain("@@id([owner_id, id])");
+	});
+
+	test("chat messages include stable ids, delivery state, and retry metadata", () => {
+		const chatMessage = modelBody("chat_message");
+
+		expect(chatMessage).toContain("id");
+		expect(chatMessage).toContain("@id");
+		expect(chatMessage).toContain("sender_id");
+		expect(chatMessage).toContain("status");
+		expect(chatMessage).toContain("created_at");
+		expect(chatMessage).toContain("sort_at");
+		expect(chatMessage).toContain("retry_count");
+		expect(chatMessage).toContain("error_message");
+	});
+
+	test("friend requests are persisted for inbound and outbound flows", () => {
+		const friendRequest = modelBody("friend_request");
+
+		expect(friendRequest).toContain("owner_id");
+		expect(friendRequest).toContain("remote_id");
+		expect(friendRequest).toContain("direction");
+		expect(friendRequest).toContain("status");
+		expect(friendRequest).toContain("created_at");
+		expect(friendRequest).toContain(
+			"@@unique([owner_id, remote_id, direction])",
+		);
+	});
+});
+
+describe("TypeScript endpoint contract", () => {
+	test("messages expose id, delivery status, sortable time, and retry metadata", () => {
+		expect(endpointTypes).toContain("export type MessageStatus");
+		expect(endpointTypes).toContain("id: string");
+		expect(endpointTypes).toContain("owner_id: string");
+		expect(endpointTypes).toContain("chat_user_id: string");
+		expect(endpointTypes).toContain("sender_id: string");
+		expect(endpointTypes).toContain("status: MessageStatus");
+		expect(endpointTypes).toContain("sort_at: number");
+		expect(endpointTypes).toContain("retry_count: number");
+		expect(endpointTypes).toContain("error_message?: string | null");
+	});
+
+	test("friend requests have shared status and direction types", () => {
+		expect(endpointTypes).toContain("export type FriendRequestStatus");
+		expect(endpointTypes).toContain("export type FriendRequestDirection");
+		expect(endpointTypes).toContain("export type FriendRequest =");
+	});
+});

--- a/src/components/ui/chat_bar.tsx
+++ b/src/components/ui/chat_bar.tsx
@@ -8,6 +8,20 @@ import { QueryBuilder } from "~/lib/query_builder";
 import { MainContext, ShellContext, use_context } from "../context";
 import Image from "../widgets/image";
 
+const messageStatusText = (message: Message | undefined) => {
+	if (message?.status === "sending") return "发送中";
+	if (message?.status === "failed") return message.error_message ?? "发送失败";
+	return "已发送";
+};
+
+const messageTimeText = (message: Message | undefined) => {
+	if (!message) return "";
+	return new Date(message.created_at).toLocaleTimeString([], {
+		hour: "2-digit",
+		minute: "2-digit",
+	});
+};
+
 export default function ChatBar(props: { chat_user: User }) {
 	const shell_store = use_context(ShellContext);
 	const main_store = use_context(MainContext);
@@ -17,9 +31,21 @@ export default function ChatBar(props: { chat_user: User }) {
 		if (!u) throw new Error("用户不存在");
 		return await main_store.sqlite.query<Message>(
 			QueryBuilder.selectFrom("chat_message")
-				.select(["chat_user_id", "timestamp", "content"])
+				.select([
+					"id",
+					"owner_id",
+					"chat_user_id",
+					"sender_id",
+					"content",
+					"status",
+					"created_at",
+					"sort_at",
+					"retry_count",
+					"error_message",
+				])
 				.where("owner_id", "=", u.id)
 				.where("chat_user_id", "=", props.chat_user.id)
+				.orderBy("sort_at", "asc")
 				.compile(),
 		);
 	});
@@ -70,56 +96,61 @@ export default function ChatBar(props: { chat_user: User }) {
 							}}
 						>
 							<For each={message_list_virtualizer.getVirtualItems()}>
-								{(v) => (
-									<div
-										class={twMerge(
-											"chat p-0",
-											messages()?.at(v.index)?.sender_id === props.chat_user.id
-												? "chat-start"
-												: "chat-end",
-										)}
-									>
-										<div class="chat-image avatar">
-											<Show
-												keyed
-												when={
-													messages()?.at(v.index)?.sender_id ===
-													props.chat_user.id
-														? props.chat_user.avatar
-														: user()?.avatar
-												}
-												fallback={
-													<UserIcon class="size-10 rounded-full bg-base-300" />
-												}
-											>
-												{(avatar) => (
-													<Image class="size-10 rounded-full" image={avatar} />
-												)}
-											</Show>
-										</div>
-										<div class="chat-header items-center">
-											<span
-												class={twMerge(
-													"text-sm text-base-content font-bold",
-													messages()?.at(v.index)?.sender_id ===
-														props.chat_user.id
-														? undefined
-														: "order-1",
-												)}
-											>
-												{messages()?.at(v.index)?.sender_id ===
-												props.chat_user.id
-													? props.chat_user.name
-													: user()?.name}
+								{(v) => {
+									const message = () => messages()?.at(v.index);
+									const is_remote_message = () =>
+										message()?.sender_id === props.chat_user.id;
+									return (
+										<div
+											class={twMerge(
+												"chat p-0",
+												is_remote_message() ? "chat-start" : "chat-end",
+											)}
+										>
+											<div class="chat-image avatar">
+												<Show
+													keyed
+													when={
+														is_remote_message()
+															? props.chat_user.avatar
+															: user()?.avatar
+													}
+													fallback={
+														<UserIcon class="size-10 rounded-full bg-base-300" />
+													}
+												>
+													{(avatar) => (
+														<Image
+															class="size-10 rounded-full"
+															image={avatar}
+														/>
+													)}
+												</Show>
+											</div>
+											<div class="chat-header items-center">
+												<span
+													class={twMerge(
+														"text-sm text-base-content font-bold",
+														is_remote_message() ? undefined : "order-1",
+													)}
+												>
+													{is_remote_message()
+														? props.chat_user.name
+														: user()?.name}
+												</span>
+												<time class="text-base-content/60">
+													{messageTimeText(message())}
+												</time>
+											</div>
+											<span class="border rounded-box bg-base-100 border-neutral-200 p-2">
+												{message()?.content}
 											</span>
-											<time class="text-base-content/60">12:45</time>
+											<div class="chat-footer text-base-content/60">
+												{messageStatusText(message())}
+											</div>
 										</div>
-										<span class="border rounded-box bg-base-100 border-neutral-200 p-2">
-											{messages()?.at(v.index)?.content}
-										</span>
-										<div class="chat-footer text-base-content/60">已读</div>
-									</div>
-								)}
+									);
+								}}
 							</For>
 						</div>
 					</div>

--- a/src/lib/endpoint/types.ts
+++ b/src/lib/endpoint/types.ts
@@ -13,8 +13,36 @@ export type RelayConfig = {
 	quic_port: number;
 };
 
+export type MessageStatus = "sending" | "sent" | "failed";
+
 export type Message = {
+	id: string;
+	owner_id: string;
+	chat_user_id: string;
 	sender_id: string;
-	timestamp: number;
 	content: string;
+	status: MessageStatus;
+	created_at: string;
+	sort_at: number;
+	retry_count: number;
+	error_message?: string | null;
+};
+
+export type FriendRequestStatus =
+	| "pending"
+	| "accepted"
+	| "rejected"
+	| "failed";
+
+export type FriendRequestDirection = "incoming" | "outgoing";
+
+export type FriendRequest = {
+	id: string;
+	owner_id: string;
+	remote_id: string;
+	direction: FriendRequestDirection;
+	status: FriendRequestStatus;
+	created_at: string;
+	sort_at: number;
+	error_message?: string | null;
 };


### PR DESCRIPTION
## Summary
- Scope friend uniqueness by `(owner_id, id)` so different local accounts can store the same remote friend id independently.
- Expand `chat_message` with stable ids, sender id, delivery status, sortable time, retry count, and error metadata.
- Add a minimal `friend_request` schema and TypeScript friend/message contract types.
- Update `ChatBar` to query the expanded message fields in sortable order and display message time/status.
- Add a schema/type contract check under `check:schema-contract`.

## Validation
- `bun run generate:db-schema`
- `bun run check`

Note: generated database and IPC artifacts are ignored by the repository, so they were refreshed locally for validation but are not part of the tracked diff.