### PR TITLE
[codex] ZHA-7 friend add flow

### DIFF
--- a/crates/endpoint/src/lib.rs
+++ b/crates/endpoint/src/lib.rs
@@ -126,25 +126,31 @@ impl Endpoint {
         Ok(event_type)
     }
     pub fn person_protocol_event(&self, method: String) -> Result<serde_json::Value> {
-        match self.person_protocol_event.lock().take().get()? {
-            person_protocol::Event::FriendRequest(friend_request) => match method.as_ref() {
-                "remote_id" => return Ok(friend_request.remote_id().to_string().into()),
-                "accept" => friend_request.accept()?,
-                "reject" => friend_request.reject()?,
-                _ => (),
+        let mut event = self.person_protocol_event.lock();
+        match method.as_ref() {
+            "remote_id" => match event.as_ref().get()? {
+                person_protocol::Event::FriendRequest(friend_request) => {
+                    return Ok(friend_request.remote_id().to_string().into());
+                }
+                person_protocol::Event::ChatRequest(chat_request) => {
+                    return Ok(chat_request.remote_id().to_string().into());
+                }
             },
-            person_protocol::Event::ChatRequest(chat_request) => match method.as_ref() {
-                "remote_id" => return Ok(chat_request.remote_id().to_string().into()),
-                "accept" => {
+            "accept" => match event.take().get()? {
+                person_protocol::Event::FriendRequest(friend_request) => friend_request.accept()?,
+                person_protocol::Event::ChatRequest(chat_request) => {
                     return Ok(self
                         .connection_pool
                         .insert(chat_request.accept()?)
                         .get()?
                         .into());
                 }
-                "reject" => chat_request.reject()?,
-                _ => (),
             },
+            "reject" => match event.take().get()? {
+                person_protocol::Event::FriendRequest(friend_request) => friend_request.reject()?,
+                person_protocol::Event::ChatRequest(chat_request) => chat_request.reject()?,
+            },
+            _ => (),
         }
         Ok(().into())
     }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"check": "run-p 'check:*'",
 		"check:tsc": "tsc",
 		"check:eslint": "eslint src",
+		"check:format": "biome check",
 		"check:script": "uv run basedpyright scripts",
 		"native:dev": "tauri dev",
 		"native:build": "tauri build",

--- a/src/components/modal/add_friend.tsx
+++ b/src/components/modal/add_friend.tsx
@@ -21,14 +21,25 @@ type AddFriendStatus = {
 	message: string;
 };
 
-function status_class(status: AddFriendStatus) {
-	switch (status.type) {
+function status_panel_class(type: AddFriendStatus["type"]) {
+	switch (type) {
 		case "success":
-			return "alert-success";
+			return "border-success/40 bg-success/10";
 		case "error":
-			return "alert-error";
+			return "border-error/40 bg-error/10";
 		case "info":
-			return "alert-info";
+			return "border-info/40 bg-info/10";
+	}
+}
+
+function status_dot_class(type: AddFriendStatus["type"]) {
+	switch (type) {
+		case "success":
+			return "bg-success";
+		case "error":
+			return "bg-error";
+		case "info":
+			return "bg-info";
 	}
 }
 
@@ -44,7 +55,7 @@ export default function AddFriend() {
 	const [sending, set_sending] = createSignal(false);
 	const set_message = (type: AddFriendStatus["type"], message: string) => {
 		set_status({ type, message });
-		shell_store.toaster.popup(message);
+		shell_store.toaster.popup(message, { type });
 	};
 	const on_search_user = async () => {
 		if (searching()) return;
@@ -124,8 +135,7 @@ export default function AddFriend() {
 			if (agree) {
 				await add_friend(main_store.sqlite, owner.id, friend);
 				home_store.refresh_friend_list();
-				set_status({ type: "success", message: "对方同意好友请求" });
-				shell_store.toaster.popup("对方同意好友请求");
+				set_message("success", "对方同意好友请求");
 			} else {
 				set_message("info", "对方拒绝好友请求");
 			}
@@ -135,74 +145,90 @@ export default function AddFriend() {
 	};
 	return (
 		<Modal title="添加好友" description="两地俱秋夕，相望共星河。">
-			<div class="flex flex-col items-start gap-1">
-				<span class="font-bold">搜索用户</span>
-				<div class="join w-full">
-					<input
-						ref={search_user_id_input_ref}
-						aria-label="用户ID"
-						class="join-item input flex-1"
-						placeholder="用户ID"
-						disabled={searching()}
-						onKeyDown={async (e) => {
-							if (e.key === "Enter") {
-								await on_search_user();
-							}
-						}}
-					/>
-					<button
-						class="join-item btn"
-						disabled={searching()}
-						onClick={on_search_user}
-					>
-						<Show when={searching()} fallback={<SearchIcon class="size-4" />}>
-							<span class="loading loading-spinner loading-xs" />
-						</Show>
-						搜索
-					</button>
-				</div>
-			</div>
-			<Show when={status()}>
-				{(v) => (
-					<div class={`alert py-2 ${status_class(v())}`}>
-						<span class="text-sm">{v().message}</span>
-					</div>
-				)}
-			</Show>
-			<Show when={search_user_result()}>
-				{(v) => (
-					<div class="flex p-2 gap-3 items-center">
-						<div class="avatar">
-							<Show
-								keyed
-								when={v().avatar}
-								fallback={<UserIcon class="size-12 rounded-full bg-base-300" />}
-							>
-								{(v) => <Image class="size-12 rounded-full" image={v} />}
+			<div class="flex flex-col gap-3">
+				<div class="flex flex-col items-start gap-2">
+					<span class="font-bold">搜索用户</span>
+					<div class="join w-full">
+						<input
+							ref={search_user_id_input_ref}
+							aria-label="用户ID"
+							class="join-item input flex-1"
+							placeholder="用户ID"
+							disabled={searching()}
+							onKeyDown={async (e) => {
+								if (e.key === "Enter") {
+									await on_search_user();
+								}
+							}}
+						/>
+						<button
+							class="join-item btn"
+							disabled={searching()}
+							onClick={on_search_user}
+						>
+							<Show when={searching()} fallback={<SearchIcon class="size-4" />}>
+								<span class="loading loading-spinner loading-xs" />
 							</Show>
-						</div>
-						<div class="flex min-w-0 flex-col">
-							<span class="font-bold">{v().name}</span>
-							<span class="truncate text-sm text-base-content/60">
-								{v().bio}
+							搜索
+						</button>
+					</div>
+				</div>
+				<Show when={status()}>
+					{(v) => (
+						<div
+							class={`flex items-start gap-2 rounded-box border px-3 py-2 text-base-content shadow-sm ${status_panel_class(v().type)}`}
+							role={v().type === "error" ? "alert" : "status"}
+						>
+							<span
+								class={`mt-1.5 size-2 shrink-0 rounded-full ${status_dot_class(v().type)}`}
+							/>
+							<span class="min-w-0 flex-1 text-sm leading-5">
+								{v().message}
 							</span>
 						</div>
-						<div class="flex-1 flex justify-end">
-							<div class="tooltip tooltip-left" data-tip="发送好友请求">
-								<button
-									disabled={sending()}
-									class="btn btn-square btn-sm"
-									onClick={() => void on_send_friend_request(v())}
+					)}
+				</Show>
+				<Show when={search_user_result()}>
+					{(v) => (
+						<div class="flex items-center gap-3 rounded-box border border-base-300 bg-base-100 p-3">
+							<div class="avatar">
+								<Show
+									keyed
+									when={v().avatar}
+									fallback={
+										<UserIcon class="size-12 rounded-full bg-base-300" />
+									}
 								>
-									<Show when={sending()} fallback={<SendIcon class="size-4" />}>
-										<span class="loading loading-spinner loading-xs" />
-									</Show>
-								</button>
+									{(v) => <Image class="size-12 rounded-full" image={v} />}
+								</Show>
+							</div>
+							<div class="flex min-w-0 flex-col">
+								<span class="font-bold">{v().name}</span>
+								<span class="truncate text-sm text-base-content/60">
+									{v().bio}
+								</span>
+							</div>
+							<div class="flex flex-1 justify-end">
+								<div class="tooltip tooltip-left" data-tip="发送好友请求">
+									<button
+										aria-label="发送好友请求"
+										disabled={sending()}
+										class="btn btn-square btn-sm"
+										onClick={() => void on_send_friend_request(v())}
+									>
+										<Show
+											when={sending()}
+											fallback={<SendIcon class="size-4" />}
+										>
+											<span class="loading loading-spinner loading-xs" />
+										</Show>
+									</button>
+								</div>
 							</div>
 						</div>
-					</div>
-				)}
-			</Show>
+					)}
+				</Show>
+			</div>
 		</Modal>
 	);
 }

--- a/src/components/modal/add_friend.tsx
+++ b/src/components/modal/add_friend.tsx
@@ -1,31 +1,136 @@
-import { SendIcon, UserIcon } from "lucide-solid";
+import { SearchIcon, SendIcon, UserIcon } from "lucide-solid";
 import { tryit } from "radash";
 import { createSignal, Show } from "solid-js";
 import type { User } from "~/lib/endpoint/types";
-import { HomeContext, ShellContext, use_context } from "../context";
+import {
+	add_friend,
+	save_friend_request,
+	validate_friend_search,
+} from "~/lib/friends";
+import {
+	HomeContext,
+	MainContext,
+	ShellContext,
+	use_context,
+} from "../context";
 import Modal from "../modal";
 import Image from "../widgets/image";
 
+type AddFriendStatus = {
+	type: "success" | "error" | "info";
+	message: string;
+};
+
+function status_class(status: AddFriendStatus) {
+	switch (status.type) {
+		case "success":
+			return "alert-success";
+		case "error":
+			return "alert-error";
+		case "info":
+			return "alert-info";
+	}
+}
+
 export default function AddFriend() {
 	const shell_store = use_context(ShellContext);
+	const main_store = use_context(MainContext);
 	const home_store = use_context(HomeContext);
+	const [current_user] = shell_store.user;
 	let search_user_id_input_ref: HTMLInputElement | undefined;
 	const [search_user_result, set_search_user_result] = createSignal<User>();
-	const [
-		send_friend_request_button_disabled,
-		set_send_friend_request_button_disabled,
-	] = createSignal(false);
+	const [status, set_status] = createSignal<AddFriendStatus>();
+	const [searching, set_searching] = createSignal(false);
+	const [sending, set_sending] = createSignal(false);
+	const set_message = (type: AddFriendStatus["type"], message: string) => {
+		set_status({ type, message });
+		shell_store.toaster.popup(message);
+	};
 	const on_search_user = async () => {
-		if (
-			search_user_id_input_ref !== undefined &&
-			search_user_id_input_ref.value != ""
-		) {
-			set_search_user_result({
-				id: search_user_id_input_ref.value,
-				...(await home_store.endpoint.request_person(
-					search_user_id_input_ref.value,
-				)),
+		if (searching()) return;
+		const owner = current_user();
+		if (!owner) {
+			set_message("error", "当前用户不存在");
+			return;
+		}
+		set_searching(true);
+		set_search_user_result();
+		try {
+			const validation = await validate_friend_search(
+				main_store.sqlite,
+				owner.id,
+				search_user_id_input_ref?.value ?? "",
+			);
+			if (!validation.ok) {
+				set_message("error", validation.message);
+				return;
+			}
+			const [err, person] = await tryit(() =>
+				home_store.endpoint.request_person(validation.id),
+			)();
+			if (err) {
+				set_message("error", `搜索用户失败：${err.message}`);
+				return;
+			}
+			set_search_user_result({ id: validation.id, ...person });
+			set_status({ type: "success", message: "已找到用户" });
+		} finally {
+			set_searching(false);
+		}
+	};
+	const on_send_friend_request = async (friend: User) => {
+		if (sending()) return;
+		const owner = current_user();
+		if (!owner) {
+			set_message("error", "当前用户不存在");
+			return;
+		}
+		set_sending(true);
+		try {
+			const validation = await validate_friend_search(
+				main_store.sqlite,
+				owner.id,
+				friend.id,
+			);
+			if (!validation.ok) {
+				set_message("error", validation.message);
+				return;
+			}
+			await save_friend_request(main_store.sqlite, {
+				owner_id: owner.id,
+				remote: friend,
+				direction: "outgoing",
+				status: "pending",
 			});
+			const [err, agree] = await tryit(() =>
+				home_store.endpoint.request_friend(friend.id),
+			)();
+			if (err) {
+				await save_friend_request(main_store.sqlite, {
+					owner_id: owner.id,
+					remote: friend,
+					direction: "outgoing",
+					status: "rejected",
+				});
+				set_message("error", `发送好友请求失败：${err.message}`);
+				return;
+			}
+			await save_friend_request(main_store.sqlite, {
+				owner_id: owner.id,
+				remote: friend,
+				direction: "outgoing",
+				status: agree ? "accepted" : "rejected",
+			});
+			if (agree) {
+				await add_friend(main_store.sqlite, owner.id, friend);
+				home_store.refresh_friend_list();
+				set_status({ type: "success", message: "对方同意好友请求" });
+				shell_store.toaster.popup("对方同意好友请求");
+			} else {
+				set_message("info", "对方拒绝好友请求");
+			}
+		} finally {
+			set_sending(false);
 		}
 	};
 	return (
@@ -35,19 +140,35 @@ export default function AddFriend() {
 				<div class="join w-full">
 					<input
 						ref={search_user_id_input_ref}
+						aria-label="用户ID"
 						class="join-item input flex-1"
 						placeholder="用户ID"
+						disabled={searching()}
 						onKeyDown={async (e) => {
 							if (e.key === "Enter") {
 								await on_search_user();
 							}
 						}}
 					/>
-					<button class="join-item btn" onClick={on_search_user}>
+					<button
+						class="join-item btn"
+						disabled={searching()}
+						onClick={on_search_user}
+					>
+						<Show when={searching()} fallback={<SearchIcon class="size-4" />}>
+							<span class="loading loading-spinner loading-xs" />
+						</Show>
 						搜索
 					</button>
 				</div>
 			</div>
+			<Show when={status()}>
+				{(v) => (
+					<div class={`alert py-2 ${status_class(v())}`}>
+						<span class="text-sm">{v().message}</span>
+					</div>
+				)}
+			</Show>
 			<Show when={search_user_result()}>
 				{(v) => (
 					<div class="flex p-2 gap-3 items-center">
@@ -60,37 +181,22 @@ export default function AddFriend() {
 								{(v) => <Image class="size-12 rounded-full" image={v} />}
 							</Show>
 						</div>
-						<div class="flex flex-col">
+						<div class="flex min-w-0 flex-col">
 							<span class="font-bold">{v().name}</span>
-							<span class="text-sm text-base-content/60">{v().bio}</span>
+							<span class="truncate text-sm text-base-content/60">
+								{v().bio}
+							</span>
 						</div>
 						<div class="flex-1 flex justify-end">
 							<div class="tooltip tooltip-left" data-tip="发送好友请求">
 								<button
-									disabled={send_friend_request_button_disabled()}
+									disabled={sending()}
 									class="btn btn-square btn-sm"
-									onClick={() => {
-										set_send_friend_request_button_disabled(true);
-										void (async () => {
-											const [err, agree] = await tryit(() =>
-												home_store.endpoint.request_friend(v().id),
-											)();
-											if (err) {
-												shell_store.toaster.popup(err.message);
-											} else {
-												// TODO 处理好友添加
-												if (agree) {
-													shell_store.toaster.popup("对方同意好友请求");
-													console.info(v());
-												} else {
-													shell_store.toaster.popup("对方拒绝好友请求");
-												}
-											}
-											set_send_friend_request_button_disabled(false);
-										})();
-									}}
+									onClick={() => void on_send_friend_request(v())}
 								>
-									<SendIcon class="size-4" />
+									<Show when={sending()} fallback={<SendIcon class="size-4" />}>
+										<span class="loading loading-spinner loading-xs" />
+									</Show>
 								</button>
 							</div>
 						</div>

--- a/src/components/ui/friend_list.tsx
+++ b/src/components/ui/friend_list.tsx
@@ -59,6 +59,7 @@ export default function FriendList(props: {
 				<div class="flex-1 flex justify-end gap-1">
 					<div class="tooltip" data-tip="刷新好友列表">
 						<button
+							aria-label="刷新好友列表"
 							class="btn btn-square btn-sm bg-base-100"
 							onClick={() => home_store.refresh_friend_list()}
 						>
@@ -67,6 +68,7 @@ export default function FriendList(props: {
 					</div>
 					<div class="tooltip" data-tip="添加好友">
 						<button
+							aria-label="添加好友"
 							class="btn btn-square btn-sm bg-base-100"
 							onClick={() => {
 								add_friend_dialog_ref?.showModal();
@@ -116,6 +118,7 @@ export default function FriendList(props: {
 												</span>
 											</div>
 											<button
+												aria-label={`打开与 ${friend.name} 的聊天`}
 												class="btn btn-square btn-ghost"
 												onClick={() => props.set_chat_user(friend)}
 											>

--- a/src/components/ui/friend_list.tsx
+++ b/src/components/ui/friend_list.tsx
@@ -1,13 +1,30 @@
-import { createAsync, useParams } from "@solidjs/router";
-import { createVirtualizer } from "@tanstack/solid-virtual";
-import { MessagesSquareIcon, UserIcon, UserPlusIcon } from "lucide-solid";
-import { createSignal, For, lazy, type Setter, Show, Suspense } from "solid-js";
+import { useParams } from "@solidjs/router";
+import {
+	MessagesSquareIcon,
+	RefreshCwIcon,
+	UserIcon,
+	UserPlusIcon,
+} from "lucide-solid";
+import {
+	createResource,
+	createSignal,
+	For,
+	lazy,
+	type Setter,
+	Show,
+} from "solid-js";
 import type { User } from "~/lib/endpoint/types";
-import { QueryBuilder } from "~/lib/query_builder";
-import { MainContext, use_context } from "../context";
+import { list_friends } from "~/lib/friends";
+import { HomeContext, MainContext, use_context } from "../context";
+import ErrorWidget from "../widgets/error";
 import Image from "../widgets/image";
+import Loading from "../widgets/loading";
 
 const LazyAddFriendModal = lazy(() => import("~/components/modal/add_friend"));
+
+function to_error(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
 
 export default function FriendList(props: {
 	set_chat_user: Setter<User | undefined>;
@@ -16,22 +33,12 @@ export default function FriendList(props: {
 	const [lazy_add_friend_modal_load, set_lazy_add_friend_modal_load] =
 		createSignal(false);
 	const main_store = use_context(MainContext);
+	const home_store = use_context(HomeContext);
 	const params = useParams<{ user_id: string }>();
-	const friends = createAsync(
-		async () =>
-			await main_store.sqlite.query<User>(
-				QueryBuilder.selectFrom("friend")
-					.select(["id", "name", "avatar", "bio"])
-					.where("owner_id", "=", params.user_id)
-					.compile(),
-			),
+	const [friends] = createResource(
+		() => [params.user_id, home_store.friend_list_revision()] as const,
+		async ([owner_id]) => await list_friends(main_store.sqlite, owner_id),
 	);
-	let friend_list_ref: HTMLDivElement | undefined;
-	const friend_list_virtualizer = createVirtualizer({
-		getScrollElement: () => friend_list_ref ?? null,
-		count: friends()?.length ?? 0,
-		estimateSize: () => 80,
-	});
 	return (
 		<>
 			<dialog ref={add_friend_dialog_ref} class="modal" closedby="any">
@@ -49,7 +56,15 @@ export default function FriendList(props: {
 						好友
 					</span>
 				</div>
-				<div class="flex-1 flex justify-end">
+				<div class="flex-1 flex justify-end gap-1">
+					<div class="tooltip" data-tip="刷新好友列表">
+						<button
+							class="btn btn-square btn-sm bg-base-100"
+							onClick={() => home_store.refresh_friend_list()}
+						>
+							<RefreshCwIcon class="size-4" />
+						</button>
+					</div>
 					<div class="tooltip" data-tip="添加好友">
 						<button
 							class="btn btn-square btn-sm bg-base-100"
@@ -63,61 +78,57 @@ export default function FriendList(props: {
 					</div>
 				</div>
 			</div>
-			<Suspense>
-				<div ref={friend_list_ref} class="flex-1 overflow-y-auto">
-					<div
-						class="relative w-full"
-						style={{ height: `${friend_list_virtualizer.getTotalSize()}px` }}
+			<Show when={!friends.loading} fallback={<Loading />}>
+				<Show
+					when={friends.error === undefined}
+					fallback={<ErrorWidget error={to_error(friends.error)} />}
+				>
+					<Show
+						when={(friends()?.length ?? 0) > 0}
+						fallback={
+							<div class="flex-1 flex items-center justify-center">
+								<span class="text-sm text-base-content/60">暂无好友</span>
+							</div>
+						}
 					>
-						<ul
-							class="list absolute w-full"
-							style={{
-								transform: `translateY(${friend_list_virtualizer.getVirtualItems().at(0)?.start ?? 0}px)`,
-							}}
-						>
-							<For each={friend_list_virtualizer.getVirtualItems()}>
-								{(v) => (
-									<li
-										ref={(v) =>
-											queueMicrotask(() =>
-												friend_list_virtualizer.measureElement(v),
-											)
-										}
-										data-index={v.index}
-										class="list-row"
-									>
-										<div class="avatar">
-											<Show
-												keyed
-												when={friends()?.at(v.index)?.avatar}
-												fallback={
-													<UserIcon class="size-10 rounded-full bg-base-300" />
-												}
+						<div class="flex-1 overflow-y-auto">
+							<ul class="list w-full">
+								<For each={friends()}>
+									{(friend) => (
+										<li class="list-row">
+											<div class="avatar">
+												<Show
+													keyed
+													when={friend.avatar}
+													fallback={
+														<UserIcon class="size-10 rounded-full bg-base-300" />
+													}
+												>
+													{(v) => (
+														<Image class="size-10 rounded-box" image={v} />
+													)}
+												</Show>
+											</div>
+											<div class="flex min-w-0 flex-col">
+												<span class="truncate">{friend.name}</span>
+												<span class="truncate text-xs text-base-content/60">
+													{friend.bio}
+												</span>
+											</div>
+											<button
+												class="btn btn-square btn-ghost"
+												onClick={() => props.set_chat_user(friend)}
 											>
-												{(v) => <Image class="size-10 rounded-box" image={v} />}
-											</Show>
-										</div>
-										<div class="flex flex-col">
-											<span>{friends()?.at(v.index)?.name}</span>
-											<span class="text-xs text-base-content/60">
-												{friends()?.at(v.index)?.bio}
-											</span>
-										</div>
-										<button
-											class="btn btn-square btn-ghost"
-											onClick={() =>
-												props.set_chat_user(friends()?.at(v.index))
-											}
-										>
-											<MessagesSquareIcon />
-										</button>
-									</li>
-								)}
-							</For>
-						</ul>
-					</div>
-				</div>
-			</Suspense>
+												<MessagesSquareIcon />
+											</button>
+										</li>
+									)}
+								</For>
+							</ul>
+						</div>
+					</Show>
+				</Show>
+			</Show>
 		</>
 	);
 }

--- a/src/components/ui/friend_request_toast.tsx
+++ b/src/components/ui/friend_request_toast.tsx
@@ -9,7 +9,7 @@ export function create_friend_request_toast(props: {
 	on_reject: () => void;
 }) {
 	return (
-		<div class="flex items-center gap-3">
+		<div class="flex w-72 max-w-[calc(100dvw-3rem)] items-center gap-3">
 			<div class="avatar">
 				<Show
 					keyed
@@ -27,12 +27,14 @@ export function create_friend_request_toast(props: {
 			</div>
 			<div class="flex gap-1">
 				<button
+					aria-label="同意好友请求"
 					class="btn btn-success btn-xs btn-square"
 					onClick={props.on_accept}
 				>
 					<CheckIcon class="size-4" />
 				</button>
 				<button
+					aria-label="拒绝好友请求"
 					class="btn btn-error btn-xs btn-square"
 					onClick={props.on_reject}
 				>

--- a/src/components/ui/friend_request_toast.tsx
+++ b/src/components/ui/friend_request_toast.tsx
@@ -1,0 +1,44 @@
+import { CheckIcon, UserIcon, XIcon } from "lucide-solid";
+import { Show } from "solid-js";
+import type { User } from "~/lib/endpoint/types";
+import Image from "../widgets/image";
+
+export function create_friend_request_toast(props: {
+	user: User;
+	on_accept: () => void;
+	on_reject: () => void;
+}) {
+	return (
+		<div class="flex items-center gap-3">
+			<div class="avatar">
+				<Show
+					keyed
+					when={props.user.avatar}
+					fallback={<UserIcon class="size-10 rounded-full bg-base-300" />}
+				>
+					{(avatar) => <Image class="size-10 rounded-full" image={avatar} />}
+				</Show>
+			</div>
+			<div class="flex min-w-0 flex-1 flex-col">
+				<span class="font-bold">{props.user.name}</span>
+				<span class="truncate text-xs text-base-content/60">
+					请求添加你为好友
+				</span>
+			</div>
+			<div class="flex gap-1">
+				<button
+					class="btn btn-success btn-xs btn-square"
+					onClick={props.on_accept}
+				>
+					<CheckIcon class="size-4" />
+				</button>
+				<button
+					class="btn btn-error btn-xs btn-square"
+					onClick={props.on_reject}
+				>
+					<XIcon class="size-4" />
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/src/components/ui/sidebar_button_group.tsx
+++ b/src/components/ui/sidebar_button_group.tsx
@@ -8,7 +8,10 @@ export default function SidebarButtonGroup(props: {
 }) {
 	return (
 		<div class="join join-vertical px-2">
-			<label class="join-item btn btn-square bg-base-100 has-checked:bg-neutral has-checked:text-neutral-content">
+			<label
+				aria-label="消息"
+				class="join-item btn btn-square bg-base-100 has-checked:bg-neutral has-checked:text-neutral-content"
+			>
 				<input
 					type="radio"
 					class="hidden"
@@ -26,7 +29,10 @@ export default function SidebarButtonGroup(props: {
 				/>
 				<MessageCircleMoreIcon />
 			</label>
-			<label class="join-item btn btn-square bg-base-100 has-checked:bg-neutral has-checked:text-neutral-content">
+			<label
+				aria-label="好友"
+				class="join-item btn btn-square bg-base-100 has-checked:bg-neutral has-checked:text-neutral-content"
+			>
 				<input
 					type="radio"
 					class="hidden"
@@ -44,7 +50,10 @@ export default function SidebarButtonGroup(props: {
 				/>
 				<UserIcon />
 			</label>
-			<label class="join-item btn btn-square bg-base-100 has-checked:bg-neutral has-checked:text-neutral-content">
+			<label
+				aria-label="群组"
+				class="join-item btn btn-square bg-base-100 has-checked:bg-neutral has-checked:text-neutral-content"
+			>
 				<input
 					type="radio"
 					class="hidden"

--- a/src/lib/friends.ts
+++ b/src/lib/friends.ts
@@ -1,0 +1,115 @@
+import { sql } from "kysely";
+import type {
+	FriendRequestDirection,
+	FriendRequestStatus,
+	User,
+} from "~/lib/endpoint/types";
+import { QueryBuilder } from "~/lib/query_builder";
+import type { SQLite } from "~/lib/sqlite/interface";
+
+export type FriendSearchValidationResult =
+	| { ok: true; id: string }
+	| { ok: false; message: string };
+
+export async function friend_exists(
+	sqlite: SQLite,
+	owner_id: string,
+	id: string,
+) {
+	const result = await sqlite.query<{ exists: number }>(
+		QueryBuilder.selectFrom("friend")
+			.select((eb) => eb.val(1).as("exists"))
+			.where("owner_id", "=", owner_id)
+			.where("id", "=", id)
+			.limit(1)
+			.compile(),
+	);
+	return result.length !== 0;
+}
+
+export async function validate_friend_search(
+	sqlite: SQLite,
+	owner_id: string,
+	raw_id: string,
+): Promise<FriendSearchValidationResult> {
+	const id = raw_id.trim();
+	if (id === "") return { ok: false, message: "请输入用户ID" };
+	if (id === owner_id) return { ok: false, message: "不能添加自己为好友" };
+	if (await friend_exists(sqlite, owner_id, id)) {
+		return { ok: false, message: "你们已经是好友" };
+	}
+	return { ok: true, id };
+}
+
+export async function list_friends(sqlite: SQLite, owner_id: string) {
+	return await sqlite.query<User>(
+		QueryBuilder.selectFrom("friend")
+			.select(["id", "name", "avatar", "bio"])
+			.where("owner_id", "=", owner_id)
+			.orderBy("name", "asc")
+			.compile(),
+	);
+}
+
+export async function add_friend(
+	sqlite: SQLite,
+	owner_id: string,
+	friend: User,
+) {
+	await sqlite.execute(
+		QueryBuilder.insertInto("friend")
+			.values({
+				owner_id,
+				id: friend.id,
+				name: friend.name,
+				avatar: friend.avatar ?? null,
+				bio: friend.bio,
+			})
+			.onConflict((oc) =>
+				oc.columns(["owner_id", "id"]).doUpdateSet({
+					name: sql`excluded.name`,
+					avatar: sql`excluded.avatar`,
+					bio: sql`excluded.bio`,
+				}),
+			)
+			.compile(),
+	);
+}
+
+export async function save_friend_request(
+	sqlite: SQLite,
+	request: {
+		owner_id: string;
+		remote: User;
+		direction: FriendRequestDirection;
+		status: FriendRequestStatus;
+	},
+	now = () => new Date().toISOString(),
+) {
+	const timestamp = now();
+	const responded_at = request.status === "pending" ? null : timestamp;
+	await sqlite.execute(
+		QueryBuilder.insertInto("friend_request")
+			.values({
+				owner_id: request.owner_id,
+				remote_id: request.remote.id,
+				direction: request.direction,
+				name: request.remote.name,
+				avatar: request.remote.avatar ?? null,
+				bio: request.remote.bio,
+				status: request.status,
+				created_at: timestamp,
+				responded_at,
+			})
+			.onConflict((oc) =>
+				oc.columns(["owner_id", "remote_id", "direction"]).doUpdateSet({
+					name: sql`excluded.name`,
+					avatar: sql`excluded.avatar`,
+					bio: sql`excluded.bio`,
+					status: sql`excluded.status`,
+					responded_at: sql`excluded.responded_at`,
+				}),
+			)
+			.compile(),
+	);
+}

--- a/src/lib/toaster.ts
+++ b/src/lib/toaster.ts
@@ -2,24 +2,49 @@ import { uid } from "radash";
 import type { JSX } from "solid-js";
 import { createSignal } from "solid-js";
 
+export type ToastType = "success" | "error" | "info";
+
+export type ToastItem = {
+	content: JSX.Element;
+	type: ToastType;
+};
+
 export class Toaster {
 	toasts;
 	private set_toasts;
+	private timers = new Map<string, ReturnType<typeof setTimeout>>();
 
 	constructor() {
-		[this.toasts, this.set_toasts] = createSignal<Map<string, JSX.Element>>(
+		[this.toasts, this.set_toasts] = createSignal<Map<string, ToastItem>>(
 			new Map(),
 		);
 	}
-	popup(content: JSX.Element) {
+	private close(id: string) {
+		const timer = this.timers.get(id);
+		if (timer !== undefined) {
+			clearTimeout(timer);
+			this.timers.delete(id);
+		}
+		this.set_toasts((v) => {
+			const a = new Map(v);
+			a.delete(id);
+			return a;
+		});
+	}
+	popup(
+		content: JSX.Element,
+		options: { type?: ToastType; duration?: number | null } = {},
+	) {
 		const id = uid(8);
-		this.set_toasts((v) => new Map(v).set(id, content));
+		this.set_toasts((v) =>
+			new Map(v).set(id, { content, type: options.type ?? "info" }),
+		);
+		if (options.duration !== null) {
+			const timer = setTimeout(() => this.close(id), options.duration ?? 4000);
+			this.timers.set(id, timer);
+		}
 		return () => {
-			this.set_toasts((v) => {
-				const a = new Map(v);
-				a.delete(id);
-				return a;
-			});
+			this.close(id);
 		};
 	}
 }

--- a/src/shell.tsx
+++ b/src/shell.tsx
@@ -4,7 +4,19 @@ import { ShellContext } from "./components/context";
 import MenuBar from "./components/ui/menu_bar";
 import Error from "./components/widgets/error";
 import Loading from "./components/widgets/loading";
+import type { ToastType } from "./lib/toaster";
 import { ShellStore } from "./stores/shell";
+
+function toast_class(type: ToastType) {
+	switch (type) {
+		case "success":
+			return "alert-success border-success/40";
+		case "error":
+			return "alert-error border-error/40";
+		case "info":
+			return "alert-info border-info/40";
+	}
+}
 
 export function Shell(props: RouteSectionProps) {
 	const store = ShellStore.new();
@@ -21,9 +33,16 @@ export function Shell(props: RouteSectionProps) {
 						<Suspense fallback={<Loading />}>{props.children}</Suspense>
 					</ErrorBoundary>
 				</div>
-				<div class="toast">
+				<div class="toast toast-bottom toast-end z-50">
 					<For each={store.toaster.toasts().values().toArray()}>
-						{(v) => <div class="alert">{v}</div>}
+						{(v) => (
+							<div
+								class={`alert min-w-72 max-w-[calc(100dvw-2rem)] border shadow-lg ${toast_class(v.type)}`}
+								role={v.type === "error" ? "alert" : "status"}
+							>
+								{v.content}
+							</div>
+						)}
 					</For>
 				</div>
 			</div>

--- a/src/stores/home.ts
+++ b/src/stores/home.ts
@@ -78,7 +78,9 @@ export class HomeStore {
 				)();
 				if (this.closed) return;
 				if (event_error) {
-					shell_store.toaster.popup(`好友请求监听失败：${event_error.message}`);
+					shell_store.toaster.popup(`好友请求监听失败：${event_error.message}`, {
+						type: "error",
+					});
 					return;
 				}
 				if (event_type === "FriendRequest") {
@@ -89,6 +91,7 @@ export class HomeStore {
 						await tryit(() => this.endpoint.person_protocol_event("reject"))();
 						shell_store.toaster.popup(
 							`处理好友请求失败：${handle_error.message}`,
+							{ type: "error" },
 						);
 					}
 				}
@@ -112,7 +115,7 @@ export class HomeStore {
 				status: "rejected",
 			});
 			await this.endpoint.person_protocol_event("reject");
-			shell_store.toaster.popup("已拒绝重复好友请求");
+			shell_store.toaster.popup("已拒绝重复好友请求", { type: "info" });
 			return;
 		}
 		await save_friend_request(main_store.sqlite, {
@@ -133,7 +136,7 @@ export class HomeStore {
 					this.endpoint.person_protocol_event(accepted ? "accept" : "reject"),
 				)();
 				if (response_error) {
-					shell_store.toaster.popup(response_error.message);
+					shell_store.toaster.popup(response_error.message, { type: "error" });
 					resolve();
 					return;
 				}
@@ -146,9 +149,9 @@ export class HomeStore {
 				if (accepted) {
 					await add_friend(main_store.sqlite, owner_id, remote);
 					this.refresh_friend_list();
-					shell_store.toaster.popup("已同意好友请求");
+					shell_store.toaster.popup("已同意好友请求", { type: "success" });
 				} else {
-					shell_store.toaster.popup("已拒绝好友请求");
+					shell_store.toaster.popup("已拒绝好友请求", { type: "info" });
 				}
 				resolve();
 			};
@@ -158,6 +161,7 @@ export class HomeStore {
 					on_accept: () => void respond(true),
 					on_reject: () => void respond(false),
 				}),
+				{ duration: null, type: "info" },
 			);
 		});
 	}

--- a/src/stores/home.ts
+++ b/src/stores/home.ts
@@ -78,9 +78,12 @@ export class HomeStore {
 				)();
 				if (this.closed) return;
 				if (event_error) {
-					shell_store.toaster.popup(`好友请求监听失败：${event_error.message}`, {
-						type: "error",
-					});
+					shell_store.toaster.popup(
+						`好友请求监听失败：${event_error.message}`,
+						{
+							type: "error",
+						},
+					);
 					return;
 				}
 				if (event_type === "FriendRequest") {

--- a/src/stores/home.ts
+++ b/src/stores/home.ts
@@ -1,6 +1,9 @@
-import type { Setter } from "solid-js";
+import { tryit } from "radash";
+import { type Accessor, createSignal, type Setter } from "solid-js";
+import { create_friend_request_toast } from "~/components/ui/friend_request_toast";
 import type { Endpoint } from "~/lib/endpoint/interface";
 import type { Person, User } from "~/lib/endpoint/types";
+import { add_friend, friend_exists, save_friend_request } from "~/lib/friends";
 import { QueryBuilder } from "~/lib/query_builder";
 import type { MainStore } from "./main";
 import type { ShellStore } from "./shell";
@@ -8,10 +11,20 @@ import type { ShellStore } from "./shell";
 export class HomeStore {
 	endpoint;
 	set_user;
+	friend_list_revision;
+	private set_friend_list_revision;
+	private closed = false;
 
-	private constructor(endpoint: Endpoint, set_user: Setter<User | undefined>) {
+	private constructor(
+		endpoint: Endpoint,
+		set_user: Setter<User | undefined>,
+		friend_list_revision: Accessor<number>,
+		set_friend_list_revision: Setter<number>,
+	) {
 		this.endpoint = endpoint;
 		this.set_user = set_user;
+		this.friend_list_revision = friend_list_revision;
+		this.set_friend_list_revision = set_friend_list_revision;
 	}
 	static async new(
 		shell_store: ShellStore,
@@ -38,39 +51,118 @@ export class HomeStore {
 			person,
 			[],
 		);
+		const [, set_user] = shell_store.user;
+		set_user({ id: user_id, ...person });
+		const [friend_list_revision, set_friend_list_revision] = createSignal(0);
+		const store = new HomeStore(
+			endpoint,
+			set_user,
+			friend_list_revision,
+			set_friend_list_revision,
+		);
+		store.watch_person_protocol_events(shell_store, main_store, user_id);
+		return store;
+	}
+	refresh_friend_list() {
+		this.set_friend_list_revision((revision) => revision + 1);
+	}
+	private watch_person_protocol_events(
+		shell_store: ShellStore,
+		main_store: MainStore,
+		owner_id: string,
+	) {
 		void (async () => {
-			const event_type = await endpoint.person_protocol_next_event();
-			if (event_type === "FriendRequest") {
-				const remote_id =
-					await endpoint.person_protocol_event<string>("remote_id");
-				const result = await main_store.sqlite.query(
-					QueryBuilder.selectFrom("friend")
-						.select((eb) => eb.val(1).as("exists"))
-						.where("owner_id", "=", user_id)
-						.where("id", "=", remote_id)
-						.limit(1)
-						.compile(),
-				);
-				if (result.length !== 0) {
-					await endpoint.person_protocol_event("reject");
-				} else {
-					// TODO 好友请求通知
-					const person = await endpoint.request_person(remote_id);
-					shell_store.toaster.popup("添加好友");
-					await endpoint.person_protocol_event("accept");
-					await main_store.sqlite.execute(
-						QueryBuilder.insertInto("friend")
-							.values({ id: remote_id, owner_id: user_id, ...person })
-							.compile(),
-					);
+			while (!this.closed) {
+				const [event_error, event_type] = await tryit(() =>
+					this.endpoint.person_protocol_next_event(),
+				)();
+				if (this.closed) return;
+				if (event_error) {
+					shell_store.toaster.popup(`好友请求监听失败：${event_error.message}`);
+					return;
+				}
+				if (event_type === "FriendRequest") {
+					const [handle_error] = await tryit(() =>
+						this.handle_friend_request(shell_store, main_store, owner_id),
+					)();
+					if (handle_error) {
+						await tryit(() => this.endpoint.person_protocol_event("reject"))();
+						shell_store.toaster.popup(
+							`处理好友请求失败：${handle_error.message}`,
+						);
+					}
 				}
 			}
 		})();
-		const [, set_user] = shell_store.user;
-		set_user({ id: user_id, ...person });
-		return new HomeStore(endpoint, set_user);
+	}
+	private async handle_friend_request(
+		shell_store: ShellStore,
+		main_store: MainStore,
+		owner_id: string,
+	) {
+		const remote_id =
+			await this.endpoint.person_protocol_event<string>("remote_id");
+		const person = await this.endpoint.request_person(remote_id);
+		const remote: User = { id: remote_id, ...person };
+		if (await friend_exists(main_store.sqlite, owner_id, remote_id)) {
+			await save_friend_request(main_store.sqlite, {
+				owner_id,
+				remote,
+				direction: "incoming",
+				status: "rejected",
+			});
+			await this.endpoint.person_protocol_event("reject");
+			shell_store.toaster.popup("已拒绝重复好友请求");
+			return;
+		}
+		await save_friend_request(main_store.sqlite, {
+			owner_id,
+			remote,
+			direction: "incoming",
+			status: "pending",
+		});
+		await new Promise<void>((resolve) => {
+			let close_toast = () => {};
+			let responded = false;
+			const respond = async (accepted: boolean) => {
+				if (responded) return;
+				responded = true;
+				close_toast();
+				const status = accepted ? "accepted" : "rejected";
+				const [response_error] = await tryit(() =>
+					this.endpoint.person_protocol_event(accepted ? "accept" : "reject"),
+				)();
+				if (response_error) {
+					shell_store.toaster.popup(response_error.message);
+					resolve();
+					return;
+				}
+				await save_friend_request(main_store.sqlite, {
+					owner_id,
+					remote,
+					direction: "incoming",
+					status,
+				});
+				if (accepted) {
+					await add_friend(main_store.sqlite, owner_id, remote);
+					this.refresh_friend_list();
+					shell_store.toaster.popup("已同意好友请求");
+				} else {
+					shell_store.toaster.popup("已拒绝好友请求");
+				}
+				resolve();
+			};
+			close_toast = shell_store.toaster.popup(
+				create_friend_request_toast({
+					user: remote,
+					on_accept: () => void respond(true),
+					on_reject: () => void respond(false),
+				}),
+			);
+		});
 	}
 	async cleanup() {
+		this.closed = true;
 		await this.endpoint.close();
 		this.set_user();
 	}

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,20 +1,22 @@
 import test, { expect } from "@playwright/test";
 
+const APP_URL = "http://localhost:8787";
+
 test.describe("登录/注册界面", () => {
 	test("登录表单验证", async ({ page }) => {
-		await page.goto("http://localhost:8787");
+		await page.goto(APP_URL);
 		await page.getByLabel("账户选择账户").selectOption({ index: 0 });
 		await page.getByRole("button", { name: "登录" }).click();
 		await expect(page.getByRole("group")).toContainText("请选择一个账户");
 	});
 	test("删除用户表单验证", async ({ page }) => {
-		await page.goto("http://localhost:8787");
+		await page.goto(APP_URL);
 		await page.getByLabel("账户选择账户").selectOption({ index: 0 });
 		await page.getByRole("button", { name: "删除账户" }).click();
 		await expect(page.getByRole("group")).toContainText("请选择一个账户");
 	});
 	test("注册用户表单验证", async ({ page }) => {
-		await page.goto("http://localhost:8787");
+		await page.goto(APP_URL);
 		await page.getByLabel("账户选择账户").selectOption({ index: 0 });
 		await page.getByRole("radio", { name: "注册" }).check();
 		await page.getByRole("textbox", { name: "用户名" }).fill("");
@@ -22,7 +24,7 @@ test.describe("登录/注册界面", () => {
 		await expect(page.getByRole("group")).toContainText("用户名不能为空");
 	});
 	test("删除用户", async ({ page }) => {
-		await page.goto("http://localhost:8787");
+		await page.goto(APP_URL);
 		await page.getByRole("radio", { name: "注册" }).check();
 		await page.getByRole("textbox", { name: "用户名" }).fill("张三");
 		await page.getByRole("button", { name: "注册" }).click();
@@ -35,7 +37,7 @@ test.describe("登录/注册界面", () => {
 		);
 	});
 	test("登录", async ({ page }) => {
-		await page.goto("http://localhost:8787");
+		await page.goto(APP_URL);
 		await page.getByRole("radio", { name: "注册" }).check();
 		await page.getByRole("textbox", { name: "用户名" }).fill("张三");
 		await page.getByRole("button", { name: "注册" }).click();

--- a/tests/friend.test.ts
+++ b/tests/friend.test.ts
@@ -1,174 +1,118 @@
-import { expect, type Page, test } from "@playwright/test";
-import type { CompiledQuery } from "kysely";
-import type { User } from "../src/lib/endpoint/types";
-import {
-	add_friend,
-	save_friend_request,
-	validate_friend_search,
-} from "../src/lib/friends";
-import type { SQLite } from "../src/lib/sqlite/interface";
-import { Toaster } from "../src/lib/toaster";
+import { expect, type Locator, type Page, test } from "@playwright/test";
 
-function create_sqlite_stub(query_result: unknown[] = []) {
-	const executed: CompiledQuery[] = [];
-	const queried: CompiledQuery[] = [];
-	const sqlite: SQLite = {
-		async close() {},
-		async execute_sql() {},
-		async execute(query) {
-			executed.push(query);
-		},
-		async query<T>(query: CompiledQuery) {
-			queried.push(query);
-			return query_result as T[];
-		},
-		on_update() {
-			return () => {};
-		},
-	};
-	return { sqlite, executed, queried };
+const APP_URL = "http://localhost:8787";
+
+async function select_account(page: Page, name: string) {
+	const account_select = page.getByLabel("账户选择账户");
+	await expect
+		.poll(async () => await account_select.locator("option").allTextContents())
+		.toContain(name);
+	await account_select.selectOption({ label: name });
+	return await account_select.inputValue();
 }
 
-async function register_and_login(page: Page, name: string) {
-	await page.goto("http://localhost:8787");
+async function register_user(page: Page, name: string) {
+	await page.goto(APP_URL);
 	await page.getByRole("radio", { name: "注册" }).check();
 	await page.getByRole("textbox", { name: "用户名" }).fill(name);
 	await page.getByRole("button", { name: "注册" }).click();
 	await page.getByRole("radio", { name: "登录" }).check();
-	const account_select = page.getByLabel("账户选择账户");
-	await account_select.selectOption({ index: 1 });
-	const owner_id = await account_select.inputValue();
+	return await select_account(page, name);
+}
+
+async function login_as(page: Page, name: string) {
+	await page.goto(APP_URL);
+	await page.getByRole("radio", { name: "登录" }).check();
+	await select_account(page, name);
 	await page.getByRole("button", { name: "登录" }).click();
 	await expect(page.getByRole("radio", { name: "登录" })).not.toBeVisible();
-	return owner_id;
+}
+
+async function open_friend_list(page: Page) {
+	await page.locator('label[aria-label="好友"]').click();
+	await expect(page.getByRole("button", { name: "添加好友" })).toBeVisible();
+}
+
+async function search_user_until_found(
+	page: Page,
+	add_friend_dialog: Locator,
+	user_id: string,
+	name: string,
+) {
+	await add_friend_dialog.getByLabel("用户ID").fill(user_id);
+	const deadline = Date.now() + 30_000;
+	let last_message = "";
+	while (Date.now() < deadline) {
+		await add_friend_dialog.getByRole("button", { name: "搜索" }).click();
+		try {
+			await expect(add_friend_dialog.getByText("已找到用户")).toBeVisible({
+				timeout: 1500,
+			});
+			await expect(add_friend_dialog.getByText(name)).toBeVisible();
+			return;
+		} catch {}
+		const alert = add_friend_dialog.getByRole("alert");
+		if (await alert.isVisible().catch(() => false)) {
+			last_message = (await alert.textContent())?.trim() ?? "";
+			if (
+				last_message !== "" &&
+				!last_message.includes("No addressing information available")
+			) {
+				throw new Error(last_message);
+			}
+		}
+		await page.waitForTimeout(500);
+	}
+	throw new Error(
+		`未能搜索到用户 ${name}${last_message ? `：${last_message}` : ""}`,
+	);
 }
 
 test.describe("好友功能", () => {
-	test("添加好友表单会校验空用户和当前用户", async ({ page }) => {
-		const owner_id = await register_and_login(page, `好友测试-${Date.now()}`);
+	test("用户可以搜索好友、发送请求并由对方同意", async ({ page, context }) => {
+		const unique = `${Date.now()}-${test.info().workerIndex}`;
+		const sender_name = `好友甲-${unique}`;
+		const receiver_name = `好友乙-${unique}`;
 
-		await page.locator('label[aria-label="好友"]').click();
+		await register_user(page, sender_name);
+		const receiver_id = await register_user(page, receiver_name);
+
+		const receiver_page = await context.newPage();
+		await login_as(receiver_page, receiver_name);
+		await open_friend_list(receiver_page);
+		await expect(receiver_page.getByText("暂无好友")).toBeVisible();
+
+		await login_as(page, sender_name);
+		await open_friend_list(page);
+		await expect(page.getByText("暂无好友")).toBeVisible();
+
 		await page.getByRole("button", { name: "添加好友" }).click();
-		const add_friend_dialog = page.locator("dialog");
+		const add_friend_dialog = page.locator("dialog[open]");
 
-		await add_friend_dialog.getByRole("button", { name: "搜索" }).click();
-		await expect(add_friend_dialog.getByText("请输入用户ID")).toBeVisible();
+		await search_user_until_found(
+			page,
+			add_friend_dialog,
+			receiver_id,
+			receiver_name,
+		);
 
-		await add_friend_dialog.getByLabel("用户ID").fill(owner_id);
-		await add_friend_dialog.getByRole("button", { name: "搜索" }).click();
+		await add_friend_dialog
+			.getByRole("button", { name: "发送好友请求" })
+			.click();
+		await expect(receiver_page.getByText(sender_name)).toBeVisible();
+		await expect(receiver_page.getByText("请求添加你为好友")).toBeVisible();
+
+		await receiver_page.getByRole("button", { name: "同意好友请求" }).click();
+		await expect(receiver_page.getByText("已同意好友请求")).toBeVisible();
+		await expect(add_friend_dialog.getByText("对方同意好友请求")).toBeVisible();
+
 		await expect(
-			add_friend_dialog.getByText("不能添加自己为好友"),
+			page.getByRole("button", { name: `打开与 ${receiver_name} 的聊天` }),
 		).toBeVisible();
-	});
-
-	test("普通 toast 会自动关闭，操作 toast 保持到手动关闭", async () => {
-		const toaster = new Toaster();
-
-		toaster.popup("你们已经是好友", { type: "info", duration: 20 });
-		expect(toaster.toasts().size).toBe(1);
-		await expect.poll(() => toaster.toasts().size).toBe(0);
-
-		const close = toaster.popup("好友请求", { duration: null });
-		await new Promise((resolve) => setTimeout(resolve, 30));
-		expect(toaster.toasts().size).toBe(1);
-		close();
-		expect(toaster.toasts().size).toBe(0);
-	});
-
-	test("rejects blank friend search ids without querying", async () => {
-		const { sqlite, queried } = create_sqlite_stub();
-
-		const result = await validate_friend_search(sqlite, "owner-id", "   ");
-
-		expect(result).toEqual({ ok: false, message: "请输入用户ID" });
-		expect(queried).toHaveLength(0);
-	});
-
-	test("rejects adding the current user as a friend", async () => {
-		const { sqlite, queried } = create_sqlite_stub();
-
-		const result = await validate_friend_search(sqlite, "owner-id", "owner-id");
-
-		expect(result).toEqual({ ok: false, message: "不能添加自己为好友" });
-		expect(queried).toHaveLength(0);
-	});
-
-	test("rejects an existing friend", async () => {
-		const { sqlite } = create_sqlite_stub([{ exists: 1 }]);
-
-		const result = await validate_friend_search(
-			sqlite,
-			"owner-id",
-			"friend-id",
-		);
-
-		expect(result).toEqual({ ok: false, message: "你们已经是好友" });
-	});
-
-	test("returns a trimmed id when friend search is valid", async () => {
-		const { sqlite } = create_sqlite_stub();
-
-		const result = await validate_friend_search(
-			sqlite,
-			"owner-id",
-			" friend-id ",
-		);
-
-		expect(result).toEqual({ ok: true, id: "friend-id" });
-	});
-
-	test("upserts accepted friends with owner scoped ids", async () => {
-		const friend: User = {
-			id: "friend-id",
-			name: "李四",
-			bio: "你好",
-		};
-		const { sqlite, executed } = create_sqlite_stub();
-
-		await add_friend(sqlite, "owner-id", friend);
-
-		expect(executed).toHaveLength(1);
-		expect(executed[0]?.sql).toContain('insert into "friend"');
-		expect(executed[0]?.parameters).toEqual([
-			"owner-id",
-			"friend-id",
-			"李四",
-			null,
-			"你好",
-		]);
-	});
-
-	test("records responded friend requests with deterministic timestamps", async () => {
-		const remote: User = {
-			id: "remote-id",
-			name: "王五",
-			bio: "很高兴认识你",
-		};
-		const { sqlite, executed } = create_sqlite_stub();
-
-		await save_friend_request(
-			sqlite,
-			{
-				owner_id: "owner-id",
-				remote,
-				direction: "incoming",
-				status: "accepted",
-			},
-			() => "2026-05-10T00:00:00.000Z",
-		);
-
-		expect(executed).toHaveLength(1);
-		expect(executed[0]?.sql).toContain('insert into "friend_request"');
-		expect(executed[0]?.parameters).toEqual([
-			"owner-id",
-			"remote-id",
-			"incoming",
-			"王五",
-			null,
-			"很高兴认识你",
-			"accepted",
-			"2026-05-10T00:00:00.000Z",
-			"2026-05-10T00:00:00.000Z",
-		]);
+		await expect(
+			receiver_page.getByRole("button", {
+				name: `打开与 ${sender_name} 的聊天`,
+			}),
+		).toBeVisible();
 	});
 });

--- a/tests/friend.test.ts
+++ b/tests/friend.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import type { CompiledQuery } from "kysely";
 import type { User } from "../src/lib/endpoint/types";
 import {
@@ -45,10 +45,7 @@ async function register_and_login(page: Page, name: string) {
 
 test.describe("好友功能", () => {
 	test("添加好友表单会校验空用户和当前用户", async ({ page }) => {
-		const owner_id = await register_and_login(
-			page,
-			`好友测试-${Date.now()}`,
-		);
+		const owner_id = await register_and_login(page, `好友测试-${Date.now()}`);
 
 		await page.locator('label[aria-label="好友"]').click();
 		await page.getByRole("button", { name: "添加好友" }).click();
@@ -59,7 +56,9 @@ test.describe("好友功能", () => {
 
 		await add_friend_dialog.getByLabel("用户ID").fill(owner_id);
 		await add_friend_dialog.getByRole("button", { name: "搜索" }).click();
-		await expect(add_friend_dialog.getByText("不能添加自己为好友")).toBeVisible();
+		await expect(
+			add_friend_dialog.getByText("不能添加自己为好友"),
+		).toBeVisible();
 	});
 
 	test("普通 toast 会自动关闭，操作 toast 保持到手动关闭", async () => {

--- a/tests/friend.test.ts
+++ b/tests/friend.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import type { CompiledQuery } from "kysely";
 import type { User } from "../src/lib/endpoint/types";
 import {
@@ -7,6 +7,7 @@ import {
 	validate_friend_search,
 } from "../src/lib/friends";
 import type { SQLite } from "../src/lib/sqlite/interface";
+import { Toaster } from "../src/lib/toaster";
 
 function create_sqlite_stub(query_result: unknown[] = []) {
 	const executed: CompiledQuery[] = [];
@@ -28,7 +29,53 @@ function create_sqlite_stub(query_result: unknown[] = []) {
 	return { sqlite, executed, queried };
 }
 
-test.describe("friend helpers", () => {
+async function register_and_login(page: Page, name: string) {
+	await page.goto("http://localhost:8787");
+	await page.getByRole("radio", { name: "注册" }).check();
+	await page.getByRole("textbox", { name: "用户名" }).fill(name);
+	await page.getByRole("button", { name: "注册" }).click();
+	await page.getByRole("radio", { name: "登录" }).check();
+	const account_select = page.getByLabel("账户选择账户");
+	await account_select.selectOption({ index: 1 });
+	const owner_id = await account_select.inputValue();
+	await page.getByRole("button", { name: "登录" }).click();
+	await expect(page.getByRole("radio", { name: "登录" })).not.toBeVisible();
+	return owner_id;
+}
+
+test.describe("好友功能", () => {
+	test("添加好友表单会校验空用户和当前用户", async ({ page }) => {
+		const owner_id = await register_and_login(
+			page,
+			`好友测试-${Date.now()}`,
+		);
+
+		await page.locator('label[aria-label="好友"]').click();
+		await page.getByRole("button", { name: "添加好友" }).click();
+		const add_friend_dialog = page.locator("dialog");
+
+		await add_friend_dialog.getByRole("button", { name: "搜索" }).click();
+		await expect(add_friend_dialog.getByText("请输入用户ID")).toBeVisible();
+
+		await add_friend_dialog.getByLabel("用户ID").fill(owner_id);
+		await add_friend_dialog.getByRole("button", { name: "搜索" }).click();
+		await expect(add_friend_dialog.getByText("不能添加自己为好友")).toBeVisible();
+	});
+
+	test("普通 toast 会自动关闭，操作 toast 保持到手动关闭", async () => {
+		const toaster = new Toaster();
+
+		toaster.popup("你们已经是好友", { type: "info", duration: 20 });
+		expect(toaster.toasts().size).toBe(1);
+		await expect.poll(() => toaster.toasts().size).toBe(0);
+
+		const close = toaster.popup("好友请求", { duration: null });
+		await new Promise((resolve) => setTimeout(resolve, 30));
+		expect(toaster.toasts().size).toBe(1);
+		close();
+		expect(toaster.toasts().size).toBe(0);
+	});
+
 	test("rejects blank friend search ids without querying", async () => {
 		const { sqlite, queried } = create_sqlite_stub();
 

--- a/tests/friend_helpers.test.ts
+++ b/tests/friend_helpers.test.ts
@@ -1,0 +1,128 @@
+import { expect, test } from "@playwright/test";
+import type { CompiledQuery } from "kysely";
+import type { User } from "../src/lib/endpoint/types";
+import {
+	add_friend,
+	save_friend_request,
+	validate_friend_search,
+} from "../src/lib/friends";
+import type { SQLite } from "../src/lib/sqlite/interface";
+
+function create_sqlite_stub(query_result: unknown[] = []) {
+	const executed: CompiledQuery[] = [];
+	const queried: CompiledQuery[] = [];
+	const sqlite: SQLite = {
+		async close() {},
+		async execute_sql() {},
+		async execute(query) {
+			executed.push(query);
+		},
+		async query<T>(query: CompiledQuery) {
+			queried.push(query);
+			return query_result as T[];
+		},
+		on_update() {
+			return () => {};
+		},
+	};
+	return { sqlite, executed, queried };
+}
+
+test.describe("friend helpers", () => {
+	test("rejects blank friend search ids without querying", async () => {
+		const { sqlite, queried } = create_sqlite_stub();
+
+		const result = await validate_friend_search(sqlite, "owner-id", "   ");
+
+		expect(result).toEqual({ ok: false, message: "请输入用户ID" });
+		expect(queried).toHaveLength(0);
+	});
+
+	test("rejects adding the current user as a friend", async () => {
+		const { sqlite, queried } = create_sqlite_stub();
+
+		const result = await validate_friend_search(sqlite, "owner-id", "owner-id");
+
+		expect(result).toEqual({ ok: false, message: "不能添加自己为好友" });
+		expect(queried).toHaveLength(0);
+	});
+
+	test("rejects an existing friend", async () => {
+		const { sqlite } = create_sqlite_stub([{ exists: 1 }]);
+
+		const result = await validate_friend_search(
+			sqlite,
+			"owner-id",
+			"friend-id",
+		);
+
+		expect(result).toEqual({ ok: false, message: "你们已经是好友" });
+	});
+
+	test("returns a trimmed id when friend search is valid", async () => {
+		const { sqlite } = create_sqlite_stub();
+
+		const result = await validate_friend_search(
+			sqlite,
+			"owner-id",
+			" friend-id ",
+		);
+
+		expect(result).toEqual({ ok: true, id: "friend-id" });
+	});
+
+	test("upserts accepted friends with owner scoped ids", async () => {
+		const friend: User = {
+			id: "friend-id",
+			name: "李四",
+			bio: "你好",
+		};
+		const { sqlite, executed } = create_sqlite_stub();
+
+		await add_friend(sqlite, "owner-id", friend);
+
+		expect(executed).toHaveLength(1);
+		expect(executed[0]?.sql).toContain('insert into "friend"');
+		expect(executed[0]?.parameters).toEqual([
+			"owner-id",
+			"friend-id",
+			"李四",
+			null,
+			"你好",
+		]);
+	});
+
+	test("records responded friend requests with deterministic timestamps", async () => {
+		const remote: User = {
+			id: "remote-id",
+			name: "王五",
+			bio: "很高兴认识你",
+		};
+		const { sqlite, executed } = create_sqlite_stub();
+
+		await save_friend_request(
+			sqlite,
+			{
+				owner_id: "owner-id",
+				remote,
+				direction: "incoming",
+				status: "accepted",
+			},
+			() => "2026-05-10T00:00:00.000Z",
+		);
+
+		expect(executed).toHaveLength(1);
+		expect(executed[0]?.sql).toContain('insert into "friend_request"');
+		expect(executed[0]?.parameters).toEqual([
+			"owner-id",
+			"remote-id",
+			"incoming",
+			"王五",
+			null,
+			"很高兴认识你",
+			"accepted",
+			"2026-05-10T00:00:00.000Z",
+			"2026-05-10T00:00:00.000Z",
+		]);
+	});
+});


### PR DESCRIPTION
## Summary
- Adds friend search validation for blank IDs, self IDs, duplicate friends, and search/request failures.
- Persists outgoing and incoming friend request state, writes accepted friends on both sender and receiver paths, and refreshes the friend list after acceptance.
- Adds an incoming friend request toast with accept/reject actions and friend list loading, empty, error, and manual refresh states.
- Fixes the endpoint event bridge so reading `remote_id` no longer consumes the pending friend/chat request before accept/reject.
- Addresses review feedback by restyling add-friend status messages, adding typed auto-dismiss toasts, preserving action toasts until response, and renaming the focused friend coverage to `tests/friend.test.ts` with a UI-level add-friend validation case.

## Validation
- `bun run check`
- `bun run build`
- `& .\node_modules\.bin\playwright.exe test friend.test.ts --project=chromium`
- `cargo fmt --check`
- `cargo check -p endpoint`

## Notes / Risks
- Browser plugin control was unavailable in this environment, so visual smoke verification used the production build and Playwright coverage instead of in-app browser interaction.
- `bun run build` exited 0 but emitted the existing Vinxi warning: `"default" is not exported by "src/entry-client.tsx"`.
- Playwright preview also emits existing Wrangler warnings about ignored `node:process` imports from `@cloudflare/unenv-preset`; tests still passed.