### PR TITLE
[codex] add one-to-one text messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 /public/db_schema.sql
 /keystore.properties
+/temp.db

--- a/crates/endpoint/src/lib.rs
+++ b/crates/endpoint/src/lib.rs
@@ -15,7 +15,7 @@ use iroh_gossip::{
 };
 use iroh_relay::RelayQuicConfig;
 use parking_lot::Mutex;
-use person_protocol::{Person, PersonProtocol};
+use person_protocol::{ChatTextMessage, Person, PersonProtocol};
 use serde::{Deserialize, Serialize};
 use sharded_slab::Slab;
 use utils::option_ext::OptionGet;
@@ -167,6 +167,18 @@ impl Endpoint {
             .await?
             .map(|v| self.connection_pool.insert(v).get())
             .transpose()?)
+    }
+    pub async fn send_chat_text_message(
+        &self,
+        connection: usize,
+        message: ChatTextMessage,
+    ) -> Result<()> {
+        let connection = self.connection_pool.get(connection).get()?.clone();
+        PersonProtocol::send_chat_text_message(&connection, message).await
+    }
+    pub async fn next_chat_text_message(&self, connection: usize) -> Result<ChatTextMessage> {
+        let connection = self.connection_pool.get(connection).get()?.clone();
+        PersonProtocol::next_chat_text_message(&connection).await
     }
     pub async fn subscribe_group(&self, ticket: String) -> Result<usize> {
         let ticket = serde_json::from_slice::<Ticket>(&BASE64_STANDARD.decode(ticket)?)?;

--- a/crates/person-protocol/src/lib.rs
+++ b/crates/person-protocol/src/lib.rs
@@ -35,6 +35,16 @@ pub struct Person {
     pub bio: String,
 }
 
+#[derive(
+    Archive, rkyv::Serialize, rkyv::Deserialize, Debug, Clone, serde::Serialize, serde::Deserialize,
+)]
+pub struct ChatTextMessage {
+    pub id: String,
+    pub sender_id: String,
+    pub created_at: String,
+    pub content: String,
+}
+
 #[derive(Display)]
 pub enum Event {
     FriendRequest(FriendRequest),
@@ -197,6 +207,22 @@ impl PersonProtocol {
             return Ok(None);
         }
         Ok(Some(connection))
+    }
+    pub async fn send_chat_text_message(
+        connection: &Connection,
+        message: ChatTextMessage,
+    ) -> Result<()> {
+        let mut send = connection.open_uni().await?;
+        send.write_all(&rkyv::to_bytes::<rkyv::rancor::Error>(&message)?)
+            .await?;
+        send.finish()?;
+        Ok(())
+    }
+    pub async fn next_chat_text_message(connection: &Connection) -> Result<ChatTextMessage> {
+        let mut recv = connection.accept_uni().await?;
+        Ok(rkyv::from_bytes::<ChatTextMessage, rkyv::rancor::Error>(
+            &recv.read_to_end(64 * 1024).await?,
+        )?)
     }
 }
 impl ProtocolHandler for PersonProtocol {

--- a/native/src/router/endpoint_api.rs
+++ b/native/src/router/endpoint_api.rs
@@ -29,6 +29,15 @@ pub trait EndpointApi {
     async fn request_person(handle: usize, id: String) -> Result<serde_json::Value, String>;
     async fn request_friend(handle: usize, id: String) -> Result<bool, String>;
     async fn request_chat(handle: usize, id: String) -> Result<Option<usize>, String>;
+    async fn send_chat_text_message(
+        handle: usize,
+        connection: usize,
+        message: serde_json::Value,
+    ) -> Result<(), String>;
+    async fn next_chat_text_message(
+        handle: usize,
+        connection: usize,
+    ) -> Result<serde_json::Value, String>;
     async fn subscribe_group(handle: usize, ticket: String) -> Result<usize, String>;
 }
 
@@ -171,6 +180,41 @@ impl EndpointApi for EndpointApiImpl {
             .request_chat(id)
             .await
             .mse()?)
+    }
+    async fn send_chat_text_message(
+        self,
+        handle: usize,
+        connection: usize,
+        message: serde_json::Value,
+    ) -> Result<(), String> {
+        async {
+            self.endpoint_pool
+                .get_owned(handle)
+                .get()?
+                .send_chat_text_message(connection, serde_json::from_value(message)?)
+                .await?;
+            eyre::Ok(())
+        }
+        .await
+        .mse()
+    }
+    async fn next_chat_text_message(
+        self,
+        handle: usize,
+        connection: usize,
+    ) -> Result<serde_json::Value, String> {
+        async {
+            eyre::Ok(serde_json::to_value(
+                &self
+                    .endpoint_pool
+                    .get_owned(handle)
+                    .get()?
+                    .next_chat_text_message(connection)
+                    .await?,
+            )?)
+        }
+        .await
+        .mse()
     }
     async fn subscribe_group(self, handle: usize, ticket: String) -> Result<usize, String> {
         Ok(self

--- a/schema.prisma
+++ b/schema.prisma
@@ -28,7 +28,7 @@ model friend {
 }
 
 model chat_message {
-  id           String   @id
+  id           String
   owner_id     String
   chat_user_id String
   sender_id    String
@@ -39,6 +39,7 @@ model chat_message {
   retry_count  Int      @default(0)
   last_error   String?
 
+  @@id([owner_id, id])
   @@index([owner_id, chat_user_id, created_at])
   @@index([owner_id, status])
 }

--- a/src/components/ui/chat_bar.tsx
+++ b/src/components/ui/chat_bar.tsx
@@ -1,15 +1,15 @@
 import { createAsync } from "@solidjs/router";
-import { createVirtualizer } from "@tanstack/solid-virtual";
 import { UserIcon } from "lucide-solid";
-import { For, onMount, Show, Suspense } from "solid-js";
+import { createSignal, For, onMount, Show, Suspense } from "solid-js";
 import { twMerge } from "tailwind-merge";
 import type {
 	ChatConnectionState,
 	ChatConnectionStatus,
 	Message,
+	MessageStatus,
 	User,
 } from "~/lib/endpoint/types";
-import { QueryBuilder } from "~/lib/query_builder";
+import { list_chat_messages } from "~/lib/messages";
 import {
 	HomeContext,
 	MainContext,
@@ -43,43 +43,55 @@ function chat_connection_badge_class(state: ChatConnectionState) {
 	);
 }
 
+function message_status_label(status: MessageStatus) {
+	switch (status) {
+		case "sending":
+			return "发送中";
+		case "sent":
+			return "已发送";
+		case "failed":
+			return "发送失败";
+		case "received":
+			return "已接收";
+	}
+}
+
+function format_message_time(value: string) {
+	return new Date(value).toLocaleTimeString("zh-CN", {
+		hour: "2-digit",
+		minute: "2-digit",
+	});
+}
+
 export default function ChatBar(props: { chat_user: User }) {
 	const shell_store = use_context(ShellContext);
 	const main_store = use_context(MainContext);
 	const home_store = use_context(HomeContext);
 	const [user] = shell_store.user;
+	const [draft_message, set_draft_message] = createSignal("");
 	onMount(() => void home_store.connect_chat(props.chat_user.id));
 	const connection_state = () =>
 		home_store.chat_connection_state(props.chat_user.id);
 	const messages = createAsync(async () => {
 		const u = user();
 		if (!u) throw new Error("用户不存在");
-		return await main_store.sqlite.query<Message>(
-			QueryBuilder.selectFrom("chat_message")
-				.select([
-					"id",
-					"owner_id",
-					"chat_user_id",
-					"sender_id",
-					"content",
-					"status",
-					"created_at",
-					"updated_at",
-					"retry_count",
-					"last_error",
-				])
-				.where("owner_id", "=", u.id)
-				.where("chat_user_id", "=", props.chat_user.id)
-				.orderBy("created_at", "asc")
-				.compile(),
+		home_store.message_revision();
+		return await list_chat_messages(
+			main_store.sqlite,
+			u.id,
+			props.chat_user.id,
 		);
 	});
-	let message_list_ref: HTMLDivElement | undefined;
-	const message_list_virtualizer = createVirtualizer({
-		getScrollElement: () => message_list_ref ?? null,
-		count: messages()?.length ?? 0,
-		estimateSize: () => 90,
-	});
+	const send_draft_message = () => {
+		const content = draft_message().trim();
+		if (content === "") return;
+		set_draft_message("");
+		void home_store.send_chat_message(props.chat_user.id, content);
+	};
+	const message_sender_name = (message: Message) =>
+		message.sender_id === props.chat_user.id
+			? props.chat_user.name
+			: user()?.name;
 	return (
 		<div class="flex-1 flex flex-col p-2 pt-0 gap-2">
 			<div class="flex items-center border rounded-box bg-base-100 border-neutral-200 p-2 gap-2">
@@ -114,70 +126,73 @@ export default function ChatBar(props: { chat_user: User }) {
 				</div>
 			</div>
 			<Suspense>
-				<div ref={message_list_ref} class="flex-1 overflow-y-auto">
-					<div
-						class="relative w-full"
-						style={{ height: `${message_list_virtualizer.getTotalSize()}px` }}
-					>
-						<div
-							class="absolute w-full flex flex-col px-1 gap-4"
-							style={{
-								transform: `translateY(${message_list_virtualizer.getVirtualItems().at(0)?.start ?? 0}px)`,
-							}}
-						>
-							<For each={message_list_virtualizer.getVirtualItems()}>
-								{(v) => (
-									<div
-										class={twMerge(
-											"chat p-0",
-											messages()?.at(v.index)?.sender_id === props.chat_user.id
-												? "chat-start"
-												: "chat-end",
-										)}
-									>
-										<div class="chat-image avatar">
-											<Show
-												keyed
-												when={
-													messages()?.at(v.index)?.sender_id ===
-													props.chat_user.id
-														? props.chat_user.avatar
-														: user()?.avatar
-												}
-												fallback={
-													<UserIcon class="size-10 rounded-full bg-base-300" />
-												}
-											>
-												{(avatar) => (
-													<Image class="size-10 rounded-full" image={avatar} />
-												)}
-											</Show>
-										</div>
-										<div class="chat-header items-center">
-											<span
-												class={twMerge(
-													"text-sm text-base-content font-bold",
-													messages()?.at(v.index)?.sender_id ===
-														props.chat_user.id
-														? undefined
-														: "order-1",
-												)}
-											>
-												{messages()?.at(v.index)?.sender_id ===
-												props.chat_user.id
-													? props.chat_user.name
-													: user()?.name}
-											</span>
-											<time class="text-base-content/60">12:45</time>
-										</div>
-										<span class="border rounded-box bg-base-100 border-neutral-200 p-2">
-											{messages()?.at(v.index)?.content}
-										</span>
-										<div class="chat-footer text-base-content/60">已读</div>
+				<div class="flex-1 overflow-y-auto">
+					<div class="flex min-h-full flex-col px-1 gap-4">
+						<For each={messages()}>
+							{(message) => (
+								<div
+									class={twMerge(
+										"chat p-0",
+										message.sender_id === props.chat_user.id
+											? "chat-start"
+											: "chat-end",
+									)}
+								>
+									<div class="chat-image avatar">
+										<Show
+											keyed
+											when={
+												message.sender_id === props.chat_user.id
+													? props.chat_user.avatar
+													: user()?.avatar
+											}
+											fallback={
+												<UserIcon class="size-10 rounded-full bg-base-300" />
+											}
+										>
+											{(avatar) => (
+												<Image class="size-10 rounded-full" image={avatar} />
+											)}
+										</Show>
 									</div>
-								)}
-							</For>
-						</div>
+									<div class="chat-header items-center">
+										<span
+											class={twMerge(
+												"text-sm text-base-content font-bold",
+												message.sender_id === props.chat_user.id
+													? undefined
+													: "order-1",
+											)}
+										>
+											{message_sender_name(message)}
+										</span>
+										<time class="text-base-content/60">
+											{format_message_time(message.created_at)}
+										</time>
+									</div>
+									<span class="border rounded-box bg-base-100 border-neutral-200 p-2">
+										{message.content}
+									</span>
+									<div class="chat-footer flex items-center gap-2 text-base-content/60">
+										<span>{message_status_label(message.status)}</span>
+										<Show when={message.status === "failed"}>
+											<button
+												class="link link-error"
+												aria-label="重试发送消息"
+												onClick={() =>
+													void home_store.retry_chat_message(
+														props.chat_user.id,
+														message.id,
+													)
+												}
+											>
+												重试
+											</button>
+										</Show>
+									</div>
+								</div>
+							)}
+						</For>
 					</div>
 				</div>
 			</Suspense>
@@ -186,6 +201,13 @@ export default function ChatBar(props: { chat_user: User }) {
 					class="textarea flex-1 field-sizing-content resize-none min-h-0"
 					disabled={connection_state().status !== "connected"}
 					placeholder="按回车发送消息"
+					value={draft_message()}
+					onInput={(event) => set_draft_message(event.currentTarget.value)}
+					onKeyDown={(event) => {
+						if (event.key !== "Enter" || event.shiftKey) return;
+						event.preventDefault();
+						send_draft_message();
+					}}
 				/>
 			</div>
 		</div>

--- a/src/components/ui/chat_bar.tsx
+++ b/src/components/ui/chat_bar.tsx
@@ -72,6 +72,7 @@ export default function ChatBar(props: { chat_user: User }) {
 	onMount(() => void home_store.connect_chat(props.chat_user.id));
 	const connection_state = () =>
 		home_store.chat_connection_state(props.chat_user.id);
+	let preserve_next_line_break = false;
 	const messages = createAsync(async () => {
 		const u = user();
 		if (!u) throw new Error("用户不存在");
@@ -83,10 +84,29 @@ export default function ChatBar(props: { chat_user: User }) {
 		);
 	});
 	const send_draft_message = () => {
+		preserve_next_line_break = false;
 		const content = draft_message().trim();
 		if (content === "") return;
 		set_draft_message("");
 		void home_store.send_chat_message(props.chat_user.id, content);
+	};
+	const handle_draft_message_key_down = (event: KeyboardEvent) => {
+		if (event.key !== "Enter") return;
+		if (event.shiftKey) {
+			preserve_next_line_break = true;
+			return;
+		}
+		event.preventDefault();
+		send_draft_message();
+	};
+	const handle_draft_message_before_input = (event: InputEvent) => {
+		if (event.inputType !== "insertLineBreak") return;
+		if (preserve_next_line_break) {
+			preserve_next_line_break = false;
+			return;
+		}
+		event.preventDefault();
+		send_draft_message();
 	};
 	const message_sender_name = (message: Message) =>
 		message.sender_id === props.chat_user.id
@@ -203,11 +223,8 @@ export default function ChatBar(props: { chat_user: User }) {
 					placeholder="按回车发送消息"
 					value={draft_message()}
 					onInput={(event) => set_draft_message(event.currentTarget.value)}
-					onKeyDown={(event) => {
-						if (event.key !== "Enter" || event.shiftKey) return;
-						event.preventDefault();
-						send_draft_message();
-					}}
+					onKeyDown={handle_draft_message_key_down}
+					onBeforeInput={handle_draft_message_before_input}
 				/>
 			</div>
 		</div>

--- a/src/components/ui/message_list.tsx
+++ b/src/components/ui/message_list.tsx
@@ -1,0 +1,112 @@
+import { useParams } from "@solidjs/router";
+import { MessageCircleMoreIcon, RefreshCwIcon, UserIcon } from "lucide-solid";
+import { createResource, For, type Setter, Show } from "solid-js";
+import type { User } from "~/lib/endpoint/types";
+import { list_message_threads } from "~/lib/messages";
+import { HomeContext, MainContext, use_context } from "../context";
+import ErrorWidget from "../widgets/error";
+import Image from "../widgets/image";
+import Loading from "../widgets/loading";
+
+function to_error(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function format_message_time(value: string) {
+	return new Date(value).toLocaleTimeString("zh-CN", {
+		hour: "2-digit",
+		minute: "2-digit",
+	});
+}
+
+export default function MessageList(props: {
+	set_chat_user: Setter<User | undefined>;
+}) {
+	const main_store = use_context(MainContext);
+	const home_store = use_context(HomeContext);
+	const params = useParams<{ user_id: string }>();
+	const [threads] = createResource(
+		() => [params.user_id, home_store.message_revision()] as const,
+		async ([owner_id]) =>
+			await list_message_threads(main_store.sqlite, owner_id),
+	);
+	return (
+		<>
+			<div class="flex border-b border-base-300 p-2">
+				<div class="flex gap-1 border-r border-base-300 pr-2 items-center">
+					<MessageCircleMoreIcon />
+					<span class="select-none text-base-content text-sm font-bold">
+						消息
+					</span>
+				</div>
+				<div class="flex-1 flex justify-end gap-1">
+					<div class="tooltip" data-tip="刷新消息列表">
+						<button
+							aria-label="刷新消息列表"
+							class="btn btn-square btn-sm bg-base-100"
+							onClick={() => home_store.refresh_messages()}
+						>
+							<RefreshCwIcon class="size-4" />
+						</button>
+					</div>
+				</div>
+			</div>
+			<Show when={!threads.loading} fallback={<Loading />}>
+				<Show
+					when={threads.error === undefined}
+					fallback={<ErrorWidget error={to_error(threads.error)} />}
+				>
+					<Show
+						when={(threads()?.length ?? 0) > 0}
+						fallback={
+							<div class="flex-1 flex items-center justify-center">
+								<span class="text-sm text-base-content/60">暂无消息</span>
+							</div>
+						}
+					>
+						<div class="flex-1 overflow-y-auto">
+							<ul class="list w-full">
+								<For each={threads()}>
+									{(thread) => (
+										<li class="list-row">
+											<div class="avatar">
+												<Show
+													keyed
+													when={thread.avatar}
+													fallback={
+														<UserIcon class="size-10 rounded-full bg-base-300" />
+													}
+												>
+													{(avatar) => (
+														<Image class="size-10 rounded-box" image={avatar} />
+													)}
+												</Show>
+											</div>
+											<button
+												aria-label={`打开与 ${thread.name} 的消息`}
+												class="min-w-0 flex flex-1 flex-col items-stretch text-left"
+												onClick={() => props.set_chat_user(thread)}
+											>
+												<span class="flex min-w-0 items-center justify-between gap-2">
+													<span class="truncate">{thread.name}</span>
+													<time class="shrink-0 text-xs text-base-content/50">
+														{format_message_time(
+															thread.last_message_created_at,
+														)}
+													</time>
+												</span>
+												<span class="truncate text-xs text-base-content/60">
+													{thread.last_message_content}
+												</span>
+											</button>
+										</li>
+									)}
+								</For>
+							</ul>
+						</div>
+					</Show>
+				</Show>
+			</Show>
+		</>
+	);
+}

--- a/src/lib/endpoint/interface.ts
+++ b/src/lib/endpoint/interface.ts
@@ -1,4 +1,8 @@
-import type { Person, RelayConfig } from "~/lib/endpoint/types";
+import type {
+	ChatTextMessage,
+	Person,
+	RelayConfig,
+} from "~/lib/endpoint/types";
 import type { Init } from "../interface";
 import type { PersonProtocolEvent } from "./types";
 
@@ -20,5 +24,10 @@ export interface Endpoint {
 	request_person(id: string): Promise<Person>;
 	request_friend(id: string): Promise<boolean>;
 	request_chat(id: string): Promise<bigint | null>;
+	send_chat_text_message(
+		connection: bigint,
+		message: ChatTextMessage,
+	): Promise<void>;
+	next_chat_text_message(connection: bigint): Promise<ChatTextMessage>;
 	subscribe_group(ticket: string): Promise<bigint>;
 }

--- a/src/lib/endpoint/native.ts
+++ b/src/lib/endpoint/native.ts
@@ -1,6 +1,11 @@
 import { createTauRPCProxy, type JsonValue } from "~/generated/ipc_bindings";
 import type { Endpoint, EndpointModule } from "./interface";
-import type { Person, PersonProtocolEvent, RelayConfig } from "./types";
+import type {
+	ChatTextMessage,
+	Person,
+	PersonProtocolEvent,
+	RelayConfig,
+} from "./types";
 
 export class EndpointModuleImpl implements EndpointModule {
 	init() {
@@ -72,6 +77,19 @@ export class EndpointImpl implements Endpoint {
 	}
 	async request_chat(id: string) {
 		return await createTauRPCProxy().endpoint.request_chat(this.handle, id);
+	}
+	async send_chat_text_message(connection: bigint, message: ChatTextMessage) {
+		await createTauRPCProxy().endpoint.send_chat_text_message(
+			this.handle,
+			connection,
+			message,
+		);
+	}
+	async next_chat_text_message(connection: bigint) {
+		return (await createTauRPCProxy().endpoint.next_chat_text_message(
+			this.handle,
+			connection,
+		)) as unknown as ChatTextMessage;
 	}
 	async subscribe_group(ticket: string) {
 		return await createTauRPCProxy().endpoint.subscribe_group(

--- a/src/lib/endpoint/types.ts
+++ b/src/lib/endpoint/types.ts
@@ -15,6 +15,13 @@ export type RelayConfig = {
 
 export type MessageStatus = "sending" | "sent" | "failed" | "received";
 
+export type ChatTextMessage = {
+	id: string;
+	sender_id: string;
+	created_at: string;
+	content: string;
+};
+
 export type ChatConnectionStatus =
 	| "idle"
 	| "connecting"

--- a/src/lib/endpoint/web.ts
+++ b/src/lib/endpoint/web.ts
@@ -4,7 +4,11 @@ import wasm_init, {
 	get_secret_key_id as wasm_get_secret_key_id,
 } from "@pupu/endpoint";
 import wasm_url from "@pupu/endpoint/endpoint_wasm_bg.wasm?url";
-import type { Person, RelayConfig } from "~/lib/endpoint/types";
+import type {
+	ChatTextMessage,
+	Person,
+	RelayConfig,
+} from "~/lib/endpoint/types";
 import type { Endpoint, EndpointModule } from "./interface";
 import type { PersonProtocolEvent } from "./types";
 
@@ -63,6 +67,14 @@ export class EndpointImpl implements Endpoint {
 	async request_chat(id: string) {
 		const a = await this.endpoint.request_chat(id);
 		return a != undefined ? (a as unknown as bigint) : null;
+	}
+	async send_chat_text_message(connection: bigint, message: ChatTextMessage) {
+		await this.endpoint.send_chat_text_message(Number(connection), message);
+	}
+	async next_chat_text_message(connection: bigint) {
+		return (await this.endpoint.next_chat_text_message(
+			Number(connection),
+		)) as ChatTextMessage;
 	}
 	async subscribe_group(ticket: string) {
 		return (await this.endpoint.subscribe_group(ticket)) as unknown as bigint;

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -1,0 +1,178 @@
+import { sql } from "kysely";
+import type { Message, MessageStatus, User } from "~/lib/endpoint/types";
+import { list_friends } from "~/lib/friends";
+import { QueryBuilder } from "~/lib/query_builder";
+import type { SQLite } from "~/lib/sqlite/interface";
+
+export type MessageThread = User & {
+	last_message_content: string;
+	last_message_created_at: string;
+	last_message_sender_id: string;
+	last_message_status: MessageStatus;
+};
+
+export function create_chat_message_id() {
+	if (
+		globalThis.crypto !== undefined &&
+		typeof globalThis.crypto.randomUUID === "function"
+	) {
+		return globalThis.crypto.randomUUID();
+	}
+	return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export async function list_chat_messages(
+	sqlite: SQLite,
+	owner_id: string,
+	chat_user_id: string,
+) {
+	return await sqlite.query<Message>(
+		QueryBuilder.selectFrom("chat_message")
+			.select([
+				"id",
+				"owner_id",
+				"chat_user_id",
+				"sender_id",
+				"content",
+				"status",
+				"created_at",
+				"updated_at",
+				"retry_count",
+				"last_error",
+			])
+			.where("owner_id", "=", owner_id)
+			.where("chat_user_id", "=", chat_user_id)
+			.orderBy("created_at", "asc")
+			.compile(),
+	);
+}
+
+export async function get_chat_message(
+	sqlite: SQLite,
+	owner_id: string,
+	id: string,
+) {
+	return (
+		await sqlite.query<Message>(
+			QueryBuilder.selectFrom("chat_message")
+				.select([
+					"id",
+					"owner_id",
+					"chat_user_id",
+					"sender_id",
+					"content",
+					"status",
+					"created_at",
+					"updated_at",
+					"retry_count",
+					"last_error",
+				])
+				.where("owner_id", "=", owner_id)
+				.where("id", "=", id)
+				.limit(1)
+				.compile(),
+		)
+	).at(0);
+}
+
+export async function save_chat_message(sqlite: SQLite, message: Message) {
+	await sqlite.execute(
+		QueryBuilder.insertInto("chat_message")
+			.values({
+				id: message.id,
+				owner_id: message.owner_id,
+				chat_user_id: message.chat_user_id,
+				sender_id: message.sender_id,
+				content: message.content,
+				status: message.status,
+				created_at: message.created_at,
+				updated_at: message.updated_at,
+				retry_count: message.retry_count,
+				last_error: message.last_error ?? null,
+			})
+			.onConflict((oc) =>
+				oc.columns(["owner_id", "id"]).doUpdateSet({
+					chat_user_id: sql`excluded.chat_user_id`,
+					sender_id: sql`excluded.sender_id`,
+					content: sql`excluded.content`,
+					status: sql`excluded.status`,
+					updated_at: sql`excluded.updated_at`,
+					retry_count: sql`excluded.retry_count`,
+					last_error: sql`excluded.last_error`,
+				}),
+			)
+			.compile(),
+	);
+}
+
+export async function update_chat_message_status(
+	sqlite: SQLite,
+	input: {
+		owner_id: string;
+		id: string;
+		status: MessageStatus;
+		retry_count?: number;
+		last_error?: string | null;
+	},
+	now = () => new Date().toISOString(),
+) {
+	await sqlite.execute(
+		QueryBuilder.updateTable("chat_message")
+			.set({
+				status: input.status,
+				updated_at: now(),
+				...(input.retry_count === undefined
+					? {}
+					: { retry_count: input.retry_count }),
+				...(input.last_error === undefined
+					? {}
+					: { last_error: input.last_error }),
+			})
+			.where("owner_id", "=", input.owner_id)
+			.where("id", "=", input.id)
+			.compile(),
+	);
+}
+
+export async function list_message_threads(sqlite: SQLite, owner_id: string) {
+	const messages = await sqlite.query<Message>(
+		QueryBuilder.selectFrom("chat_message")
+			.select([
+				"id",
+				"owner_id",
+				"chat_user_id",
+				"sender_id",
+				"content",
+				"status",
+				"created_at",
+				"updated_at",
+				"retry_count",
+				"last_error",
+			])
+			.where("owner_id", "=", owner_id)
+			.orderBy("created_at", "desc")
+			.compile(),
+	);
+	const latest_by_chat_user = new Map<string, Message>();
+	for (const message of messages) {
+		if (!latest_by_chat_user.has(message.chat_user_id)) {
+			latest_by_chat_user.set(message.chat_user_id, message);
+		}
+	}
+	const friends = new Map(
+		(await list_friends(sqlite, owner_id)).map((friend) => [friend.id, friend]),
+	);
+	return [...latest_by_chat_user.values()]
+		.map((message): MessageThread | undefined => {
+			const friend = friends.get(message.chat_user_id);
+			if (!friend) return;
+			return {
+				...friend,
+				last_message_content: message.content,
+				last_message_created_at: message.created_at,
+				last_message_sender_id: message.sender_id,
+				last_message_status: message.status,
+			};
+		})
+		.filter((thread): thread is MessageThread => thread !== undefined);
+}

--- a/src/routes/(main)/home/[user_id].tsx
+++ b/src/routes/(main)/home/[user_id].tsx
@@ -8,6 +8,7 @@ import {
 } from "~/components/context";
 import ChatBar from "~/components/ui/chat_bar";
 import FriendList from "~/components/ui/friend_list";
+import MessageList from "~/components/ui/message_list";
 import SidebarButtonGroup, {
 	type SidebarButtonGroupState,
 } from "~/components/ui/sidebar_button_group";
@@ -39,11 +40,7 @@ export default function Home() {
 								<div class="absolute inset-0 right-4 max-w-80 flex flex-col bg-base-100 border border-base-300 rounded-t-box">
 									<Switch>
 										<Match when={sidebar_button_group_state() === "message"}>
-											<div class="flex-1 flex items-center justify-center">
-												<span class="text-base-content font-bold">
-													消息功能待实现
-												</span>
-											</div>
+											<MessageList set_chat_user={set_chat_user} />
 										</Match>
 										<Match when={sidebar_button_group_state() === "friend"}>
 											<FriendList set_chat_user={set_chat_user} />

--- a/src/stores/home.ts
+++ b/src/stores/home.ts
@@ -3,11 +3,19 @@ import { type Accessor, createSignal, type Setter } from "solid-js";
 import type { Endpoint } from "~/lib/endpoint/interface";
 import type {
 	ChatConnectionState,
+	ChatTextMessage,
+	Message,
 	Person,
 	PersonProtocolEvent,
 	User,
 } from "~/lib/endpoint/types";
 import { add_friend, friend_exists, save_friend_request } from "~/lib/friends";
+import {
+	create_chat_message_id,
+	get_chat_message,
+	save_chat_message,
+	update_chat_message_status,
+} from "~/lib/messages";
 import { QueryBuilder } from "~/lib/query_builder";
 import type { MainStore } from "./main";
 import type { ShellStore } from "./shell";
@@ -16,25 +24,41 @@ export class HomeStore {
 	endpoint;
 	set_user;
 	friend_list_revision;
+	message_revision;
 	chat_connections;
+	private shell_store;
+	private main_store;
+	private owner_id;
 	private set_friend_list_revision;
+	private set_message_revision;
 	private set_chat_connections;
 	private event_loop?: Promise<void>;
+	private chat_message_receivers = new Map<string, Promise<void>>();
 	private cleanup_handlers = new Set<() => void>();
 	private closed = false;
 
 	private constructor(
 		endpoint: Endpoint,
+		shell_store: ShellStore,
+		main_store: MainStore,
+		owner_id: string,
 		set_user: Setter<User | undefined>,
 		friend_list_revision: Accessor<number>,
 		set_friend_list_revision: Setter<number>,
+		message_revision: Accessor<number>,
+		set_message_revision: Setter<number>,
 		chat_connections: Accessor<Map<string, ChatConnectionState>>,
 		set_chat_connections: Setter<Map<string, ChatConnectionState>>,
 	) {
 		this.endpoint = endpoint;
+		this.shell_store = shell_store;
+		this.main_store = main_store;
+		this.owner_id = owner_id;
 		this.set_user = set_user;
 		this.friend_list_revision = friend_list_revision;
 		this.set_friend_list_revision = set_friend_list_revision;
+		this.message_revision = message_revision;
+		this.set_message_revision = set_message_revision;
 		this.chat_connections = chat_connections;
 		this.set_chat_connections = set_chat_connections;
 	}
@@ -66,14 +90,20 @@ export class HomeStore {
 		const [, set_user] = shell_store.user;
 		set_user({ id: user_id, ...person });
 		const [friend_list_revision, set_friend_list_revision] = createSignal(0);
+		const [message_revision, set_message_revision] = createSignal(0);
 		const [chat_connections, set_chat_connections] = createSignal<
 			Map<string, ChatConnectionState>
 		>(new Map());
 		const store = new HomeStore(
 			endpoint,
+			shell_store,
+			main_store,
+			user_id,
 			set_user,
 			friend_list_revision,
 			set_friend_list_revision,
+			message_revision,
+			set_message_revision,
 			chat_connections,
 			set_chat_connections,
 		);
@@ -82,6 +112,9 @@ export class HomeStore {
 	}
 	refresh_friend_list() {
 		this.set_friend_list_revision((revision) => revision + 1);
+	}
+	refresh_messages() {
+		this.set_message_revision((revision) => revision + 1);
 	}
 	chat_connection_state(remote_id: string): ChatConnectionState {
 		return this.chat_connections().get(remote_id) ?? { status: "idle" };
@@ -122,6 +155,135 @@ export class HomeStore {
 			status: "connected",
 			connection,
 		});
+		this.start_chat_message_receiver(remote_id, connection);
+	}
+	async send_chat_message(remote_id: string, raw_content: string) {
+		const content = raw_content.trim();
+		if (this.closed || content === "") return;
+		const created_at = new Date().toISOString();
+		const message: Message = {
+			id: create_chat_message_id(),
+			owner_id: this.owner_id,
+			chat_user_id: remote_id,
+			sender_id: this.owner_id,
+			content,
+			status: "sending",
+			created_at,
+			updated_at: created_at,
+			retry_count: 0,
+			last_error: null,
+		};
+		await save_chat_message(this.main_store.sqlite, message);
+		this.refresh_messages();
+		await this.dispatch_chat_message(remote_id, message);
+	}
+	async retry_chat_message(remote_id: string, message_id: string) {
+		if (this.closed) return;
+		const message = await get_chat_message(
+			this.main_store.sqlite,
+			this.owner_id,
+			message_id,
+		);
+		if (!message) return;
+		await update_chat_message_status(this.main_store.sqlite, {
+			owner_id: this.owner_id,
+			id: message.id,
+			status: "sending",
+			last_error: null,
+		});
+		this.refresh_messages();
+		await this.dispatch_chat_message(remote_id, {
+			...message,
+			status: "sending",
+		});
+	}
+	private async dispatch_chat_message(remote_id: string, message: Message) {
+		const state = this.chat_connection_state(remote_id);
+		if (state.status !== "connected" || state.connection === undefined) {
+			await this.fail_chat_message(message, "聊天未连接");
+			return;
+		}
+		const envelope: ChatTextMessage = {
+			id: message.id,
+			sender_id: this.owner_id,
+			created_at: message.created_at,
+			content: message.content,
+		};
+		const [send_error] = await tryit(() =>
+			this.endpoint.send_chat_text_message(
+				state.connection as bigint,
+				envelope,
+			),
+		)();
+		if (this.closed) return;
+		if (send_error) {
+			await this.fail_chat_message(message, send_error.message);
+			return;
+		}
+		await update_chat_message_status(this.main_store.sqlite, {
+			owner_id: this.owner_id,
+			id: message.id,
+			status: "sent",
+			last_error: null,
+		});
+		this.refresh_messages();
+	}
+	private async fail_chat_message(message: Message, error: string) {
+		await update_chat_message_status(this.main_store.sqlite, {
+			owner_id: this.owner_id,
+			id: message.id,
+			status: "failed",
+			retry_count: message.retry_count + 1,
+			last_error: error,
+		});
+		this.refresh_messages();
+	}
+	private start_chat_message_receiver(remote_id: string, connection: bigint) {
+		if (this.chat_message_receivers.has(remote_id)) return;
+		const receiver = this.run_chat_message_receiver(
+			remote_id,
+			connection,
+		).finally(() => this.chat_message_receivers.delete(remote_id));
+		this.chat_message_receivers.set(remote_id, receiver);
+	}
+	private async run_chat_message_receiver(
+		remote_id: string,
+		connection: bigint,
+	) {
+		while (!this.closed) {
+			const [receive_error, message] = await tryit(() =>
+				this.endpoint.next_chat_text_message(connection),
+			)();
+			if (this.closed) return;
+			if (receive_error) {
+				const current = this.chat_connection_state(remote_id);
+				if (current.connection === connection) {
+					this.set_chat_connection_state(remote_id, {
+						status: "error",
+						error: receive_error.message,
+					});
+				}
+				this.shell_store.toaster.popup(
+					`接收聊天消息失败：${receive_error.message}`,
+					{ type: "error" },
+				);
+				return;
+			}
+			const updated_at = new Date().toISOString();
+			await save_chat_message(this.main_store.sqlite, {
+				id: message.id,
+				owner_id: this.owner_id,
+				chat_user_id: remote_id,
+				sender_id: remote_id,
+				content: message.content,
+				status: "received",
+				created_at: message.created_at,
+				updated_at,
+				retry_count: 0,
+				last_error: null,
+			});
+			this.refresh_messages();
+		}
 	}
 	private watch_person_protocol_events(
 		shell_store: ShellStore,
@@ -286,12 +448,14 @@ export class HomeStore {
 			status: "connected",
 			connection,
 		});
+		this.start_chat_message_receiver(remote_id, connection);
 	}
 	async cleanup() {
 		this.closed = true;
 		for (const cleanup_handler of [...this.cleanup_handlers]) cleanup_handler();
 		const [close_error] = await tryit(() => this.endpoint.close())();
 		if (this.event_loop) await tryit(() => this.event_loop)();
+		await tryit(() => Promise.all([...this.chat_message_receivers.values()]))();
 		this.set_user();
 		if (close_error) throw close_error;
 	}

--- a/tests/home_store_events.test.ts
+++ b/tests/home_store_events.test.ts
@@ -154,6 +154,7 @@ test.describe("HomeStore 事件循环", () => {
 		const sender_name = `消息甲-${unique}`;
 		const receiver_name = `消息乙-${unique}`;
 		const message = `你好，阶段4-${unique}`;
+		const before_input_message = `换行输入-${unique}`;
 
 		await register_user(page, sender_name);
 		const receiver_id = await register_user(page, receiver_name);
@@ -191,11 +192,36 @@ test.describe("HomeStore 事件循环", () => {
 			timeout: 30_000,
 		});
 
+		const message_input = page.getByPlaceholder("按回车发送消息");
+		await message_input.fill(before_input_message);
+		const line_break_prevented = await message_input.evaluate((element) => {
+			const textarea = element as HTMLTextAreaElement;
+			const event = new InputEvent("beforeinput", {
+				bubbles: true,
+				cancelable: true,
+				inputType: "insertLineBreak",
+			});
+			const default_allowed = textarea.dispatchEvent(event);
+			if (default_allowed) {
+				textarea.value = `${textarea.value}\n`;
+				textarea.dispatchEvent(new Event("input", { bubbles: true }));
+			}
+			return !default_allowed;
+		});
+		expect(line_break_prevented).toBe(true);
+		await expect(page.getByText(before_input_message)).toBeVisible({
+			timeout: 30_000,
+		});
+		await expect(message_input).toHaveValue("");
+		await expect(receiver_page.getByText(before_input_message)).toBeVisible({
+			timeout: 30_000,
+		});
+
 		await receiver_page.locator('label[aria-label="消息"]').click();
 		const message_entry = receiver_page.getByRole("button", {
 			name: `打开与 ${sender_name} 的消息`,
 		});
 		await expect(message_entry).toBeVisible();
-		await expect(message_entry.getByText(message)).toBeVisible();
+		await expect(message_entry.getByText(before_input_message)).toBeVisible();
 	});
 });

--- a/tests/home_store_events.test.ts
+++ b/tests/home_store_events.test.ts
@@ -144,4 +144,58 @@ test.describe("HomeStore 事件循环", () => {
 			timeout: 30_000,
 		});
 	});
+
+	test("一对一文本消息会发送、接收、落库并刷新消息入口", async ({
+		page,
+		context,
+	}) => {
+		test.setTimeout(120_000);
+		const unique = `${Date.now()}-${test.info().workerIndex}`;
+		const sender_name = `消息甲-${unique}`;
+		const receiver_name = `消息乙-${unique}`;
+		const message = `你好，阶段4-${unique}`;
+
+		await register_user(page, sender_name);
+		const receiver_id = await register_user(page, receiver_name);
+
+		const receiver_page = await context.newPage();
+		await login_as(receiver_page, receiver_name);
+		await login_as(page, sender_name);
+
+		await become_friends(
+			page,
+			receiver_page,
+			receiver_id,
+			sender_name,
+			receiver_name,
+		);
+
+		await page
+			.getByRole("button", { name: `打开与 ${receiver_name} 的聊天` })
+			.click();
+		await expect(page.getByText("已连接")).toBeVisible({ timeout: 30_000 });
+
+		await receiver_page
+			.getByRole("button", { name: `打开与 ${sender_name} 的聊天` })
+			.click();
+		await expect(receiver_page.getByText("已连接")).toBeVisible({
+			timeout: 30_000,
+		});
+
+		await page.getByPlaceholder("按回车发送消息").fill(message);
+		await page.getByPlaceholder("按回车发送消息").press("Enter");
+
+		await expect(page.getByText(message)).toBeVisible({ timeout: 30_000 });
+		await expect(page.getByText("已发送")).toBeVisible();
+		await expect(receiver_page.getByText(message)).toBeVisible({
+			timeout: 30_000,
+		});
+
+		await receiver_page.locator('label[aria-label="消息"]').click();
+		const message_entry = receiver_page.getByRole("button", {
+			name: `打开与 ${sender_name} 的消息`,
+		});
+		await expect(message_entry).toBeVisible();
+		await expect(message_entry.getByText(message)).toBeVisible();
+	});
 });

--- a/wasm/endpoint/src/lib.rs
+++ b/wasm/endpoint/src/lib.rs
@@ -61,6 +61,21 @@ impl Endpoint {
     pub async fn request_chat(&self, id: String) -> Result<Option<usize>, JsError> {
         self.0.request_chat(id).await.mje()
     }
+    pub async fn send_chat_text_message(
+        &self,
+        connection: usize,
+        message: JsValue,
+    ) -> Result<(), JsError> {
+        self.0
+            .send_chat_text_message(connection, serde_wasm_bindgen::from_value(message)?)
+            .await
+            .mje()
+    }
+    pub async fn next_chat_text_message(&self, connection: usize) -> Result<JsValue, JsError> {
+        Ok(serde_wasm_bindgen::to_value(
+            &self.0.next_chat_text_message(connection).await.mje()?,
+        )?)
+    }
     pub async fn subscribe_group(&self, ticket: String) -> Result<usize, JsError> {
         self.0.subscribe_group(ticket).await.mje()
     }


### PR DESCRIPTION
## Summary
- Add endpoint text-message send/receive APIs for accepted chat connections across Rust core, WASM, native RPC, and TypeScript adapters.
- Persist one-to-one chat messages with sending/sent/failed/received states and minimal retry support.
- Refresh the open chat and add a message-entry list showing latest one-to-one messages.

## Validation
- `bun run build`
- `cargo check -p endpoint -p person-protocol -p native`
- `bunx playwright test tests/home_store_events.test.ts --project=chromium`

## Remaining Risk
- Message delivery is tied to the currently accepted chat connection and does not yet include offline sync, conflict resolution, read receipts, attachments, or group chat behavior by design.